### PR TITLE
fix(eventhandling): ignore missing Initiator in FromStreamEventsResponse

### DIFF
--- a/models/eventModel.go
+++ b/models/eventModel.go
@@ -32,7 +32,9 @@ type Event struct {
 func (e *Event) FromStreamEventsResponse(eventType string, p *Player, i *Unit, w *Weapon, t *Unit, tw *Weapon) {
 	e.Event = eventType
 	e.Player = *p
-	e.Initiator = *i
+	if e.Initiator.Type != "" {
+		e.Initiator = *i
+	}
 	e.Weapon = *w
 	if t != nil {
 		e.Target = *t


### PR DESCRIPTION
Modify FromStreamEventsResponse to ignore missing Initiator.
- Add condition to check if Initiator.Type is not empty before assignment
- Prevents errors when Initiator is missing or not set

This ensures the application handles events more robustly when the Initiator is not provided.