### PR TITLE
Run migrations as a Helm pre-upgrade hook

### DIFF
--- a/charts/overlord/Chart.yaml
+++ b/charts/overlord/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/overlord/ci/sqlite-values.yaml
+++ b/charts/overlord/ci/sqlite-values.yaml
@@ -17,3 +17,9 @@ overlord:
   environment: production
   log_level: info
   log_encoding: json
+
+# The migration job runs in its own pod, so with SQLite it would migrate a file
+# the application never sees. Off for this smoke test, which only asserts that
+# the chart renders and the pod becomes healthy.
+migrations:
+  enabled: false

--- a/charts/overlord/templates/_helpers.tpl
+++ b/charts/overlord/templates/_helpers.tpl
@@ -60,3 +60,37 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Environment shared by the application and the migration job. Both need identical
+database configuration, so it lives here rather than being duplicated.
+*/}}
+{{- define "overlord.env" -}}
+{{- if .Values.overlord.db_url }}
+- name: DB_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "overlord.fullname" . }}-secret
+      key: db_url
+{{- end }}
+{{- if .Values.service.port }}
+- name: PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "overlord.fullname" . }}-secret
+      key: port
+{{- end }}
+- name: DB_TYPE
+  value: {{ .Values.overlord.db_type | quote }}
+- name: GRPC_SERVER_ADDRESS
+  value: {{ .Values.overlord.grpc_server_address | quote }}
+- name: ENVIRONMENT
+  value: {{ .Values.overlord.environment | quote }}
+- name: LOG_LEVEL
+  value: {{ .Values.overlord.log_level | quote }}
+- name: LOG_ENCODING
+  value: {{ .Values.overlord.log_encoding | quote }}
+{{- with .Values.env }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/overlord/templates/deployment.yaml
+++ b/charts/overlord/templates/deployment.yaml
@@ -19,9 +19,9 @@ spec:
       {{- end }}
       labels:
         {{- include "overlord.labels" . | nindent 8 }}
-	{{- with .Values.podLabels }}
+      {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -55,33 +55,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-          {{- if .Values.overlord.db_url }}
-            - name: DB_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "overlord.fullname" . }}-secret
-                  key: db_url
-          {{- end }}
-          {{- if .Values.service.port }}
-            - name: PORT
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "overlord.fullname" . }}-secret
-                  key: port
-          {{- end }}
-            - name: DB_TYPE
-              value: {{ .Values.overlord.db_type | quote }}
-            - name: GRPC_SERVER_ADDRESS
-              value: {{ .Values.overlord.grpc_server_address | quote }}
-            - name: ENVIRONMENT
-              value: {{ .Values.overlord.environment | quote }}
-            - name: LOG_LEVEL
-              value: {{ .Values.overlord.log_level | quote }}
-            - name: LOG_ENCODING
-              value: {{ .Values.overlord.log_encoding | quote }}
-          {{- with .Values.env }}
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- include "overlord.env" . | nindent 12 }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/charts/overlord/templates/migrate-job.yaml
+++ b/charts/overlord/templates/migrate-job.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "overlord.fullname" . }}-migrate
+  labels:
+    {{- include "overlord.labels" . | nindent 4 }}
+  annotations:
+    # Run before the application on both install and upgrade. The schema changes
+    # are not all additive -- duplicate weapon rows are collapsed before a unique
+    # index is added, and the players.ip column is dropped along with its
+    # contents -- so migrating must complete before the new image starts, not
+    # alongside it.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    # Remove the previous job before creating this one; a completed Job is
+    # immutable, so reusing the name would otherwise fail on upgrade.
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  # A failed migration should fail the release rather than retry indefinitely.
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "overlord.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "overlord.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: migrate
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # The image sets CMD with no ENTRYPOINT, so args alone would replace
+          # the entrypoint rather than be passed to it. Both are set explicitly.
+          command: ["/app/entrypoint.sh"]
+          args: ["--migrate"]
+          env:
+            {{- include "overlord.env" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.migrations.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/overlord/values.yaml
+++ b/charts/overlord/values.yaml
@@ -52,6 +52,22 @@ overlord:
   log_level: info
   log_encoding: json
 
+# Schema migrations run as a Helm pre-install/pre-upgrade hook, so they complete
+# before the new image starts. Not every migration is additive -- duplicate
+# weapon rows are collapsed before a unique index is added, and players.ip is
+# dropped along with its contents -- so running them alongside the application
+# would leave it querying a schema that is still changing.
+migrations:
+  enabled: true
+  # Fail the release rather than retry a broken migration indefinitely.
+  backoffLimit: 1
+  resources: {}
+
+  # SQLite caveat: the job runs in its own pod, so with db_type "sqlite" it
+  # migrates a file in its own container filesystem, not the one the application
+  # sees. For SQLite either mount a shared volume via volumes/volumeMounts, or
+  # leave this disabled and migrate by hand. Postgres has no such problem.
+
 service:
   type: ClusterIP
   port: 3000


### PR DESCRIPTION
Closes #52.

Stacked on #45 (which is where the chart reaches version 0.3.0) — retarget to `main` once that merges. Branched this way deliberately: on `main` it would collide with #45 on the chart version and one of them would fail `ct lint`.

The chart deployed the application but never migrated. `entrypoint.sh` has supported `--migrate` all along; nothing invoked it. No init container, no hook, no Job.

**A pre-install/pre-upgrade hook Job**, not an init container, so it runs once per release rather than once per replica. That matters because the migration is no longer purely additive — it collapses duplicate weapon rows before adding a unique index, and drops `players.ip` with its contents. Neither is undone by rolling the image back, so it must complete *before* the new image starts. `backoffLimit: 1` so a broken migration fails the release instead of retrying forever.

The env block moves into an `overlord.env` helper, since the job and the deployment need identical database config and duplicating it invites drift.

### Two bugs found while writing it

- **The image sets `CMD` with no `ENTRYPOINT`.** Setting `args` alone on the job would have *replaced* the entrypoint, and the container would have tried to exec `--migrate`. Both `command` and `args` are now set explicitly. Worth knowing for any future manifest.
- **`deployment.yaml` had a literal tab** on line 22. It rendered correctly only because `{{-` trims preceding whitespace — changing it to `{{` would have emitted a tab into the YAML and broken the manifest. Pre-existing; now spaces.

### SQLite caveat

The job runs in its own pod, so under SQLite it migrates a file the application never sees. It is therefore **off in the CI values**, and `values.yaml` documents the options: a shared volume, or migrate by hand. Postgres is unaffected.

### Not locally validated

helm is not installed here and installing it needs administrator rights, so `ct lint` in CI is the first real render of this. I did check delimiter balance, block open/close pairing and tabs by hand.