### PR TITLE
Bump GitHub Actions to current versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@v4.1.2
         with:
           cosign-release: 'v2.2.4'
 
@@ -47,7 +47,7 @@ jobs:
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -63,7 +63,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/helm-linting.yml
+++ b/.github/workflows/helm-linting.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@v5
         with:
           version: v3.14.4
 
@@ -22,7 +22,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -24,7 +24,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
Applies the five outstanding dependabot bumps directly. They were opened in May against a `main` that has moved a long way since, and `UNKNOWN` mergeability on all six suggested none would apply cleanly. Together they amount to five one-line edits, so rebasing five branches and running CI five times costs more than it is worth.

| Action | From | To |
|---|---|---|
| azure/setup-helm | 4.2.0 | 5 |
| helm/chart-testing-action | 2.6.1 | 2.8.0 |
| docker/metadata-action | 5 | 6 |
| docker/setup-buildx-action | 3 | 4 |
| sigstore/cosign-installer | 4.1.1 | 4.1.2 |

`setup-helm` v5 is a Node runtime bump (node20 → node24) with no input changes, per its release notes.

Supersedes #23, #26, #29, #30, #31.

**Not included: #25** (golang `1.22-alpine` → `1.26-alpine`). It was opened against `1.22-alpine`; the Dockerfile is now `1.25-alpine` from #44, so the patch no longer applies. Whether to move to 1.26 is worth deciding on its own — `go.mod` requires 1.25, so 1.26 would satisfy it, but gqlgen has already bitten us once on a toolchain change and it deserves its own verification rather than riding along on a stale bump.

**Caveat:** `helm-release.yml` only runs on push to `main`, so the `setup-helm` bump in that file is not exercised by PR CI. If chart releasing breaks, that is where to look.