### PR TITLE
Harden the dashboard along modern-web guidance

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -9,8 +9,15 @@
  * Both themes are written out once and selected by data-theme on <html>. An
  * inline script in index.html sets that attribute before first paint, so there
  * is no prefers-color-scheme block here and no flash of the wrong theme.
+ *
+ * The light tokens also apply to a bare :root so the page is still styled if
+ * that script never runs. Light rather than the system preference because
+ * matching the preference without JS would mean duplicating the dark block in
+ * a media query, and a scriptless visitor sees no data anyway -- this only has
+ * to not be unstyled.
  */
 
+:root,
 :root[data-theme="light"] {
   color-scheme: light;
 
@@ -264,6 +271,11 @@ main {
   font-weight: 600;
   letter-spacing: -0.005em;
 }
+
+/* Headings break into even lines, explanatory prose avoids a lone word on its
+   last line. Both are ignored by browsers that lack them. */
+h1, h2, h3 { text-wrap: balance; }
+.note, .chart-scale { text-wrap: pretty; }
 .chips { display: flex; gap: 0.35rem; flex-wrap: wrap; }
 .chips button { font-size: 0.75rem; padding: 0.25rem 0.6rem; }
 
@@ -510,6 +522,18 @@ table.hm thead th { vertical-align: bottom; }
 .tw { overflow: auto; }
 .tw-tall { max-height: 30rem; }
 
+/* The bottom panels are heavy (the log alone is 200 rows, redrawn every poll)
+   and sit below the fold on every viewport, so the browser may skip rendering
+   them until they are scrolled near. The intrinsic size keeps the scrollbar
+   honest before first render; auto remembers the real height afterwards. Not
+   applied to the map panels: Leaflet sizes itself from its container and lays
+   the tiles out wrong if it measures while rendering is skipped. */
+#p-log, #p-collateral {
+  content-visibility: auto;
+}
+#p-log { contain-intrinsic-size: auto none auto 38rem; }
+#p-collateral { contain-intrinsic-size: auto none auto 18rem; }
+
 table.grid {
   width: 100%;
   border-collapse: collapse;
@@ -642,7 +666,7 @@ dialog.card {
    every engine, so a var() here silently resolves to nothing in anything
    slightly older and the page behind shows through unshaded. */
 dialog.card::backdrop { backdrop-filter: blur(3px); background: rgb(6 8 11 / 68%); }
-:root[data-theme="light"] dialog.card::backdrop { background: rgb(30 34 40 / 32%); }
+:root:not([data-theme="dark"]) dialog.card::backdrop { background: rgb(30 34 40 / 32%); }
 
 .card-head {
   display: flex;
@@ -954,6 +978,7 @@ footer {
 /* Gold is for glory and nothing else: record values, earned badges, first
    place. Grey stays structural, blue and red stay coalition. One warm accent,
    spent only where something was achieved. */
+:root,
 :root[data-theme="light"] { --gold: #9a6b06; --gold-dim: #c9a44a; }
 :root[data-theme="dark"] { --gold: #e3b34c; --gold-dim: #8a6d33; }
 

--- a/web/app.js
+++ b/web/app.js
@@ -1580,11 +1580,24 @@ document.addEventListener("click", (e) => {
     openCard(r.dataset.ref, r.dataset.type);
     return;
   }
-  // A modal dialog fills the viewport for hit-testing purposes, so a click on
-  // the backdrop lands on the dialog element itself rather than on anything
-  // inside it. That is the signal to close.
-  if (e.target.id === "card-close" || e.target.id === "card") closeCard();
+  if (e.target.id === "card-close") closeCard();
 });
+
+// Clicking the backdrop closes the card: closedby="any" on the element makes
+// that native where supported. Elsewhere a backdrop click lands on the dialog
+// element itself for hit-testing purposes -- but so does a click on the
+// dialog's own padding, so the point has to be tested against the box before
+// it counts as a dismissal.
+if (!("closedBy" in HTMLDialogElement.prototype)) {
+  el("card").addEventListener("click", (e) => {
+    if (e.target !== e.currentTarget) return;
+    const r = e.currentTarget.getBoundingClientRect();
+    const onDialog =
+      r.top <= e.clientY && e.clientY <= r.bottom &&
+      r.left <= e.clientX && e.clientX <= r.right;
+    if (!onDialog) closeCard();
+  });
+}
 
 // Escape and the close button are the dialog's own job now. This only covers
 // activating a reference name, which is a span rather than a button.
@@ -1622,8 +1635,23 @@ const tick = PAGE === "player" ? loadPlayer : refresh;
 let timer = null;
 function schedule() {
   clearInterval(timer);
-  if (el("live").checked) timer = setInterval(tick, REFRESH_MS);
+  // Also covers a page loaded straight into a background tab, which the
+  // visibilitychange listener below never sees a transition for.
+  if (el("live").checked && !document.hidden) timer = setInterval(tick, REFRESH_MS);
 }
+
+// A dashboard lives in background tabs, and polling a page nobody can see
+// spends battery and server alike. Hiding the tab stops the clock; coming
+// back refreshes once so the numbers are current, then restarts it. Live
+// unchecked is the user's own freeze and stays frozen across the round trip.
+document.addEventListener("visibilitychange", () => {
+  if (document.hidden) {
+    clearInterval(timer);
+  } else if (el("live").checked) {
+    tick();
+    schedule();
+  }
+});
 
 function chips(container, attr, onPick) {
   el(container).addEventListener("click", (e) => {
@@ -1693,6 +1721,11 @@ function applyTheme(mode) {
   void root.offsetHeight;
   setTimeout(() => root.classList.remove("theme-switching"), 0);
 
+  // Keep the meta declaration in step, so the browser paints native surfaces
+  // for the pinned theme rather than the light-dark pair declared for load.
+  const scheme = document.querySelector('meta[name="color-scheme"]');
+  if (scheme) scheme.content = mode;
+
   // The button names where you are going, not where you are.
   themeBtn.textContent = mode === "dark" ? "☀ Light" : "☾ Dark";
   themeBtn.setAttribute(
@@ -1729,6 +1762,7 @@ system.addEventListener("change", (e) => {
 // timestamp reads as a log line. Stops counting the moment a fetch fails,
 // since the down state owns the text then.
 setInterval(() => {
+  if (document.hidden) return;
   const link = el("link");
   if (!state.lastSync || !link.classList.contains("up")) return;
   const age = Math.round((Date.now() - state.lastSync) / 1000);

--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,9 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- Declared before any CSS arrives so the browser paints the canvas in a
+     sane colour from the first frame. app.js narrows it to the chosen theme. -->
+<meta name="color-scheme" content="light dark">
 <title>Overlord — debrief</title>
 <link rel="stylesheet" href="app.css">
 <!-- Leaflet, pinned and integrity-checked; see player.html for the reasoning. -->
@@ -160,7 +163,7 @@
      A native <dialog> opened with showModal(): the focus trap, Escape to
      close, the inert background and the backdrop all come with it. The
      hand-rolled version of this left every control behind it tabbable. -->
-<dialog id="card" class="card" aria-labelledby="card-name">
+<dialog id="card" class="card" closedby="any" aria-labelledby="card-name">
   <div class="card-head">
     <div>
       <h3 id="card-name">—</h3>

--- a/web/player.html
+++ b/web/player.html
@@ -3,6 +3,9 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- Declared before any CSS arrives so the browser paints the canvas in a
+     sane colour from the first frame. app.js narrows it to the chosen theme. -->
+<meta name="color-scheme" content="light dark">
 <title>Pilot — Overlord</title>
 <link rel="stylesheet" href="/app.css">
 <!-- Leaflet, the one external dependency in the dashboard. Pinned and
@@ -128,7 +131,7 @@
 </main>
 
 <!-- Same reference card as the dashboard; see index.html. -->
-<dialog id="card" class="card" aria-labelledby="card-name">
+<dialog id="card" class="card" closedby="any" aria-labelledby="card-name">
   <div class="card-head">
     <div>
       <h3 id="card-name">—</h3>


### PR DESCRIPTION
Six fixes from auditing the dashboard against current web platform guidance (the modern-web-guidance guide set). All are small and degrade gracefully in browsers that lack the features.

## What changed

- **Polling pauses in hidden tabs.** The 15 s poll and the 1 s "Live · Xs ago" ticker stop on `visibilitychange`, refresh once on return, and never start when the page loads straight into a background tab. Every forgotten dashboard tab was previously hitting the API around the clock. The Live checkbox stays the user's own freeze and is respected across the round trip.
- **The page is styled even if JS never runs.** All theme tokens lived under `:root[data-theme=…]`; with the pre-paint script broken, the page rendered unstyled. The light tokens now also apply to a bare `:root` (light on purpose — matching the system preference without JS would mean duplicating the dark block, and a scriptless visitor sees no data anyway).
- **`<meta name="color-scheme" content="light dark">`** in both documents, so the browser paints a sane canvas before the stylesheet arrives. The theme toggle keeps the meta in step with the pinned theme.
- **Native light dismiss for the reference card.** `closedby="any"` on the dialog gives backdrop-click and mobile back-gesture close where supported (Chrome/Edge/Firefox); the Safari fallback now tests the click point against the dialog's box, which also fixes a real bug — a click on the dialog's own padding used to close the card.
- **`content-visibility: auto`** on the event log (200 rows, redrawn every poll) and collateral panels, with `contain-intrinsic-size` so the scrollbar stays honest. Map panels deliberately excluded: Leaflet mis-lays tiles if it measures a container whose rendering is skipped.
- **Typography:** `text-wrap: balance` on headings, `text-wrap: pretty` on explanatory notes.

## Verified

- Computed styles confirmed live in the browser: `content-visibility`, `contain-intrinsic-size`, both `text-wrap` values, `closedBy: "any"`, meta sync on theme change.
- Removing `data-theme` at runtime resolves the full light theme (tokens, gold, `color-scheme`) and restores cleanly.
- Backdrop-vs-padding hit test exercised against the real dialog geometry.
- Both pages load clean (no console errors); `go vet` and the graph/controllers tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)