### PR TITLE
Add a pilot dossier of favourites to the player page

### DIFF
--- a/controllers/aggregates.go
+++ b/controllers/aggregates.go
@@ -392,6 +392,21 @@ func GetLandingGrades(limit int, missionID *uint) ([]*models.LandingGrade, error
 // ordinary player rows: asking for the blue AI gives that whole side's record
 // in the same shape as a person's.
 //
+// topFavourite crowns the largest tally in a map. Ties break alphabetically so
+// the answer is stable between refreshes; map order alone is not.
+func topFavourite(totals map[string]int) *models.Favourite {
+	var best *models.Favourite
+	for name, n := range totals {
+		if n <= 0 {
+			continue
+		}
+		if best == nil || n > best.Count || (n == best.Count && name < best.Name) {
+			best = &models.Favourite{Name: name, Count: n}
+		}
+	}
+	return best
+}
+
 // Several queries rather than one. They group by different things -- airframe,
 // weapon, matchup -- so a single statement would need either a join per
 // dimension, multiplying rows, or a window function, which is not portable
@@ -589,10 +604,14 @@ func GetPlayerProfile(playerID uint, unitType string, missionID *uint) (*models.
 	// initiator on that player's own events. Matching on it is therefore exact
 	// within a mission; across missions a reused slot name could in principle
 	// be credited to the wrong player.
-	playerUnits := onUnit(db.Model(&models.Event{})).
-		Scopes(scopeMission(missionID)).
-		Select("DISTINCT events.initiator_name").
-		Where("events.player_id = ? AND events.initiator_name <> ?", playerID, "")
+	// Built fresh per use rather than shared: the favourites below need the
+	// same subquery, and a *gorm.DB accumulates state when reused.
+	victimNames := func() *gorm.DB {
+		return onUnit(db.Model(&models.Event{})).
+			Scopes(scopeMission(missionID)).
+			Select("DISTINCT events.initiator_name").
+			Where("events.player_id = ? AND events.initiator_name <> ?", playerID, "")
+	}
 
 	var killedBy []models.Matchup
 	killedByQuery := db.Model(&models.Event{}).
@@ -602,7 +621,7 @@ func GetPlayerProfile(playerID uint, unitType string, missionID *uint) (*models.
 		Joins("JOIN units AS tunits ON tunits.unit_id = targets.unit_id").
 		Joins("JOIN units ON units.unit_id = events.initiator_unit_id").
 		Where("events.event = ? AND events.player_id <> ? AND events.target_name IN (?)",
-			"kill", playerID, playerUnits)
+			"kill", playerID, victimNames())
 
 	// Here the player's airframe is the victim, so the narrowing applies to the
 	// target side rather than the initiator.
@@ -621,6 +640,109 @@ func GetPlayerProfile(playerID uint, unitType string, missionID *uint) (*models.
 		view.KilledBy = append(view.KilledBy, &killedBy[i])
 		view.TimesKilled += killedBy[i].Kills
 	}
+
+	// Favourites: one standout answer per dossier line. The first four are
+	// maxima over aggregates computed above; the rest need their own queries
+	// because killedBy grouped away the weapon and the killer, and nothing so
+	// far has touched the mission's theatre.
+	fav := &models.Favourites{}
+
+	for _, a := range view.Aircraft { // already ordered most sorties first
+		if a.Sorties > 0 {
+			fav.Aircraft = &models.Favourite{Name: a.UnitType, Count: a.Sorties}
+			break
+		}
+	}
+
+	// Most kills; the list is ordered most fired first, so a strict > hands
+	// ties to the weapon they actually reach for.
+	for _, w := range view.Weapons {
+		if w.Kills > 0 && (fav.Weapon == nil || w.Kills > fav.Weapon.Count) {
+			fav.Weapon = &models.Favourite{Name: w.WeaponType, Count: w.Kills}
+		}
+	}
+
+	prey := map[string]int{}
+	for _, m := range view.Matchups {
+		prey[m.TargetType] += m.Kills
+	}
+	fav.Prey = topFavourite(prey)
+
+	// On the killedBy list TargetType is what did the killing; see Matchup.
+	nemeses := map[string]int{}
+	for _, m := range view.KilledBy {
+		nemeses[m.TargetType] += m.Kills
+	}
+	fav.NemesisUnit = topFavourite(nemeses)
+
+	var nemesisPilot struct {
+		ID    uint
+		Name  string
+		Total int
+	}
+	if err := db.Model(&models.Event{}).
+		Scopes(scopeMission(missionID)).
+		Select("players.player_id AS id, players.player_name AS name, COUNT(*) AS total").
+		Joins("JOIN players ON players.player_id = events.player_id").
+		Where("events.event = ? AND events.player_id <> ? AND events.target_name IN (?)",
+			"kill", playerID, victimNames()).
+		Group("players.player_id, players.player_name").
+		Order("total DESC, players.player_name").
+		Limit(1).
+		Scan(&nemesisPilot).Error; err != nil {
+		logs.Sugar.Errorf("Failed to find nemesis pilot for player %d: %v", playerID, err)
+		return nil, err
+	}
+	if nemesisPilot.Total > 0 {
+		id := nemesisPilot.ID
+		fav.NemesisPilot = &models.Favourite{ID: &id, Name: nemesisPilot.Name, Count: nemesisPilot.Total}
+	}
+
+	var deadliest struct {
+		Name  string
+		Total int
+	}
+	if err := db.Model(&models.Event{}).
+		Scopes(scopeMission(missionID)).
+		Select("weapons.type AS name, COUNT(*) AS total").
+		Joins("JOIN weapons ON weapons.weapon_id = events.weapon_id").
+		Where("events.event = ? AND events.player_id <> ? AND events.target_name IN (?)",
+			"kill", playerID, victimNames()).
+		Group("weapons.type").
+		Order("total DESC, weapons.type").
+		Limit(1).
+		Scan(&deadliest).Error; err != nil {
+		logs.Sugar.Errorf("Failed to find deadliest weapon for player %d: %v", playerID, err)
+		return nil, err
+	}
+	if deadliest.Total > 0 {
+		fav.DeadliestWeapon = &models.Favourite{Name: deadliest.Name, Count: deadliest.Total}
+	}
+
+	// Scenery excluded to match every other kill count on the profile.
+	var theatre struct {
+		Name  string
+		Total int
+	}
+	if err := onUnit(db.Model(&models.Event{})).
+		Scopes(scopeMission(missionID)).
+		Select("missions.theatre AS name, COUNT(*) AS total").
+		Joins("JOIN missions ON missions.mission_id = events.mission_id").
+		Joins("LEFT JOIN targets ON targets.target_id = events.target_id").
+		Where("events.event = ? AND events.player_id = ? AND missions.theatre <> ''", "kill", playerID).
+		Where("targets.kind IS NULL OR targets.kind <> ?", models.ObjectKindScenery).
+		Group("missions.theatre").
+		Order("total DESC, missions.theatre").
+		Limit(1).
+		Scan(&theatre).Error; err != nil {
+		logs.Sugar.Errorf("Failed to find favourite theatre for player %d: %v", playerID, err)
+		return nil, err
+	}
+	if theatre.Total > 0 {
+		fav.Theatre = &models.Favourite{Name: theatre.Name, Count: theatre.Total}
+	}
+
+	view.Favourites = fav
 
 	// Graded landings, newest first.
 	var grades []models.LandingGrade

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -64,6 +64,12 @@ models:
   PlayerAircraftStats:
     model:
       - github.com/MartinHell/overlord/models.PlayerAircraftStats
+  Favourite:
+    model:
+      - github.com/MartinHell/overlord/models.Favourite
+  Favourites:
+    model:
+      - github.com/MartinHell/overlord/models.Favourites
   Matchup:
     model:
       - github.com/MartinHell/overlord/models.Matchup

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -25,6 +25,15 @@ func (r *eventResolver) ID(ctx context.Context, obj *models.Event) (string, erro
 	return fmt.Sprintf("%v", obj.ID), nil
 }
 
+// ID is the resolver for the id field.
+func (r *favouriteResolver) ID(ctx context.Context, obj *models.Favourite) (*string, error) {
+	if obj.ID == nil {
+		return nil, nil
+	}
+	id := fmt.Sprintf("%v", *obj.ID)
+	return &id, nil
+}
+
 // PlayerID is the resolver for the playerID field.
 func (r *killRecordResolver) PlayerID(ctx context.Context, obj *models.KillRecord) (string, error) {
 	return fmt.Sprintf("%v", obj.PlayerID), nil
@@ -340,6 +349,9 @@ func (r *Resolver) BadgeAward() generated.BadgeAwardResolver { return &badgeAwar
 // Event returns generated.EventResolver implementation.
 func (r *Resolver) Event() generated.EventResolver { return &eventResolver{r} }
 
+// Favourite returns generated.FavouriteResolver implementation.
+func (r *Resolver) Favourite() generated.FavouriteResolver { return &favouriteResolver{r} }
+
 // KillRecord returns generated.KillRecordResolver implementation.
 func (r *Resolver) KillRecord() generated.KillRecordResolver { return &killRecordResolver{r} }
 
@@ -388,6 +400,7 @@ func (r *Resolver) Weapon() generated.WeaponResolver { return &weaponResolver{r}
 type (
 	badgeAwardResolver          struct{ *Resolver }
 	eventResolver               struct{ *Resolver }
+	favouriteResolver           struct{ *Resolver }
 	killRecordResolver          struct{ *Resolver }
 	missionResolver             struct{ *Resolver }
 	missionTaskResolver         struct{ *Resolver }

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -194,6 +194,39 @@ type PlayerProfile {
 
     "Where the kills happened. Roughly half of kills carry no position and are absent here."
     killPoints: [KillPoint!]!
+
+    "The dossier superlatives: favourite aircraft, worst enemy and so on."
+    favourites: Favourites!
+}
+
+"One superlative: a name and how often it earned the title."
+type Favourite {
+    "Set when the name is a pilot the client can link to, null otherwise."
+    id: ID
+    name: String!
+    count: Int!
+}
+
+"""
+The dossier lines on a pilot page, each the standout answer to one question.
+Every field is null when there is nothing to crown; the client leaves that
+line out rather than inventing a zero.
+"""
+type Favourites {
+    "Most-flown airframe, by sorties."
+    aircraft: Favourite
+    "Weapon with the most kills. Null until something has died to one."
+    weapon: Favourite
+    "The type this player has destroyed most."
+    prey: Favourite
+    "The type that has shot this player down most."
+    nemesisUnit: Favourite
+    "The pilot credited with most of this player's deaths. The per-coalition AI players count like anyone else."
+    nemesisPilot: Favourite
+    "The weapon this player has died to most."
+    deadliestWeapon: Favourite
+    "The map with most of this player's kills. Trivially the current map under a single-mission scope."
+    theatre: Favourite
 }
 
 "One kill with a place and a side, for the mission map."

--- a/models/summary.go
+++ b/models/summary.go
@@ -103,6 +103,41 @@ type PlayerProfileView struct {
 	// absent entirely when it reported neither -- which is roughly half of
 	// kills, a caveat the map has to state rather than hide.
 	KillPoints []*KillPoint
+
+	Favourites *Favourites
+}
+
+// Favourite is one superlative: a name, how often it earned the title, and a
+// player id when the name is a pilot the client can link to.
+type Favourite struct {
+	ID    *uint
+	Name  string
+	Count int
+}
+
+// Favourites are the dossier lines on a pilot page -- one standout answer per
+// question, each a maximum over an aggregate the profile already carries or a
+// dedicated query. Every field is nil when there is nothing to crown, which the
+// client renders by leaving that line out rather than inventing a zero.
+type Favourites struct {
+	// Aircraft is the most-flown airframe, by sorties.
+	Aircraft *Favourite
+	// Weapon is the weapon with the most kills. Nil until something dies to it;
+	// the client can fall back to most-fired from the weapons table.
+	Weapon *Favourite
+	// Prey is the type this player has destroyed most.
+	Prey *Favourite
+	// NemesisUnit is the type that has shot this player down most.
+	NemesisUnit *Favourite
+	// NemesisPilot is the pilot credited with the most of this player's deaths.
+	// The flattened AI players count like anyone else, so this is often an AI.
+	NemesisPilot *Favourite
+	// DeadliestWeapon is the weapon this player has died to most.
+	DeadliestWeapon *Favourite
+	// Theatre is the map this player has the most kills on. Only interesting
+	// across missions; under a single-mission scope it is trivially that
+	// mission's map, which the client hides.
+	Theatre *Favourite
 }
 
 // MapKillPoint is one kill with a place and a side, for the mission map that

--- a/web/app.css
+++ b/web/app.css
@@ -323,6 +323,46 @@ main {
   padding-top: 1.1rem;
   border-top: 1px solid var(--line);
 }
+
+/* The dossier. Same label voice as the headline numbers, but the values are
+   names rather than counts, so they stay in the text face at text size and
+   the tally drops to a subline. */
+.dossier {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(13.5rem, 1fr));
+  gap: 0.75rem;
+  margin: 0;
+}
+.dossier > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.75rem 0.9rem 0.7rem;
+  background: var(--surface-2);
+  border-radius: var(--radius-sm);
+}
+.dossier dt {
+  color: var(--text-dim);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.dossier dd {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  overflow-wrap: anywhere;
+}
+.dossier .dsub {
+  display: block;
+  margin-top: 0.2rem;
+  color: var(--text-faint);
+  font-size: 0.75rem;
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+}
 .headline div { display: flex; flex-direction: column; gap: 0.15rem; }
 .headline dt {
   color: var(--text-dim);

--- a/web/app.js
+++ b/web/app.js
@@ -689,6 +689,15 @@ const PLAYER_QUERY = `query($id: ID!, $unitType: String, $m: ID) { playerProfile
   landingGrades { unitType place grade missionTime }
   bucketSeconds timeline { t sorties kills losses shots }
   killPoints { lat lon targetType weaponType missionTime }
+  favourites {
+    aircraft { name count }
+    weapon { name count }
+    prey { name count }
+    nemesisUnit { name count }
+    nemesisPilot { id name count }
+    deadliestWeapon { name count }
+    theatre { name count }
+  }
 } }`;
 
 // Mission-clock activity, drawn as inline SVG. No chart library: this is one
@@ -1154,6 +1163,53 @@ function headline(label, value, sub) {
   }</dd></div>`;
 }
 
+// The dossier: superlatives with a name on them. Each line is the standout
+// answer to one question -- most flown, most lethal, most lethal against them.
+// A line with nothing to crown is left out rather than shown empty, and the
+// panel disappears entirely for a pilot with no story yet.
+function drawDossier(p) {
+  const f = p.favourites || {};
+  // The tally rides inside the dd: a dl group allows only dt and dd children.
+  const line = (label, value, sub) =>
+    `<div><dt>${esc(label)}</dt><dd>${value}<span class="dsub">${esc(sub)}</span></dd></div>`;
+  const n = (v, one, many) => `${v} ${v === 1 ? one : many}`;
+
+  const lines = [];
+
+  // Trivial answers are omitted: the aircraft line when the page is already
+  // narrowed to one airframe, the theatre line when the scope is one mission.
+  if (!p.unitType && f.aircraft) {
+    lines.push(line("Favourite aircraft", ref("unit", f.aircraft.name), n(f.aircraft.count, "sortie", "sorties")));
+  }
+
+  if (f.weapon) {
+    lines.push(line("Weapon of choice", ref("weapon", f.weapon.name), n(f.weapon.count, "kill", "kills")));
+  } else {
+    // Nothing has died to anything yet; most-fired is still an answer.
+    const fired = [...(p.weapons || [])].sort((a, b) => b.shots - a.shots)[0];
+    if (fired && fired.shots) {
+      lines.push(line("Weapon of choice", ref("weapon", fired.weaponType), `${n(fired.shots, "shot", "shots")}, nothing down yet`));
+    }
+  }
+
+  if (f.prey) lines.push(line("Favourite prey", ref("unit", f.prey.name), n(f.prey.count, "destroyed", "destroyed")));
+  if (f.nemesisUnit) {
+    lines.push(line("Worst enemy", ref("unit", f.nemesisUnit.name), n(f.nemesisUnit.count, "loss to it", "losses to it")));
+  }
+  if (f.nemesisPilot) {
+    lines.push(line("Nemesis", pref(f.nemesisPilot.id, f.nemesisPilot.name), n(f.nemesisPilot.count, "shoot-down", "shoot-downs")));
+  }
+  if (f.deadliestWeapon) {
+    lines.push(line("Deadliest threat", ref("weapon", f.deadliestWeapon.name), n(f.deadliestWeapon.count, "death to it", "deaths to it")));
+  }
+  if (state.scope !== "mission" && f.theatre) {
+    lines.push(line("Happy hunting ground", esc(f.theatre.name), n(f.theatre.count, "kill there", "kills there")));
+  }
+
+  el("p-dossier").hidden = lines.length === 0;
+  el("dossier").innerHTML = lines.join("");
+}
+
 function drawPlayer() {
   const p = state.player;
   if (!p) return;
@@ -1171,8 +1227,6 @@ function drawPlayer() {
   // Landings against sorties is the closest thing to "got home in one piece"
   // the event stream offers.
   const survival = p.sorties ? Math.round((p.landings / p.sorties) * 100) : null;
-  const best = [...(p.aircraft || [])].sort((a, b) => b.kills - a.kills)[0];
-  const favourite = [...(p.weapons || [])].sort((a, b) => b.shots - a.shots)[0];
 
   el("player-headline").innerHTML = [
     headline("Sorties", p.sorties),
@@ -1185,13 +1239,13 @@ function drawPlayer() {
     headline("Ejections", p.ejections),
   ].join("");
 
-  const bits = [];
-  if (!p.unitType && best && best.kills) {
-    bits.push(`Deadliest in the ${unitName(best.unitType)} with ${best.kills} kills.`);
-  }
-  if (favourite && favourite.shots) bits.push(`Reaches for the ${weaponName(favourite.weaponType)} most often.`);
-  if (p.lastSeen) bits.push(`Active between ${clock(p.firstSeen)} and ${clock(p.lastSeen)} mission time.`);
-  el("player-note").textContent = bits.join(" ");
+  // The note used to carry "deadliest in" and "reaches for" lines; those are
+  // the dossier's job now, with proper links and counts.
+  el("player-note").textContent = p.lastSeen
+    ? `Active between ${clock(p.firstSeen)} and ${clock(p.lastSeen)} mission time.`
+    : "";
+
+  drawDossier(p);
 
   // Filter and per-model page are the same control. These are real links, so a
   // narrowed view is as shareable as the pilot's own page.

--- a/web/player.html
+++ b/web/player.html
@@ -59,6 +59,13 @@
     <p class="note" id="player-note"></p>
   </section>
 
+  <!-- The dossier: one standout answer per question. Empty lines are left
+       out entirely, and the whole panel goes away when nothing is crowned. -->
+  <section class="card-panel" id="p-dossier" hidden>
+    <div class="phead"><h2>Dossier</h2></div>
+    <dl id="dossier" class="dossier"></dl>
+  </section>
+
   <section class="card-panel" id="p-badges">
     <div class="phead"><h2>Badges</h2></div>
     <p class="note">Career achievements, across every mission. Locked ones show how close you are.</p>


### PR DESCRIPTION
Adds the requested favourites to the pilot page as a **Dossier** panel — seven superlatives, each the standout answer to one question:

| Line | Crowned by |
| --- | --- |
| Favourite aircraft | most sorties |
| Weapon of choice | most kills — falls back to most fired ("…nothing down yet") |
| Favourite prey | the type they have destroyed most |
| Worst enemy | the type that shoots them down most |
| Nemesis | the pilot credited with most of their deaths, linked to their page |
| Deadliest threat | the weapon they die to most |
| Happy hunting ground | the map with most of their kills |

Aircraft and weapons open their reference cards. Everything respects the This mission / All time scope and the per-airframe narrowing.

## Design choices

- **Empty lines are omitted, not zero-filled** — and the whole panel disappears for a pilot with no story yet. Trivial answers go too: the aircraft line when the page is narrowed to one airframe, the theatre line under a single-mission scope.
- Most lines are maxima over aggregates the profile already computed; only the deaths pair (killer pilot, killing weapon) and the theatre needed new queries, since `killedBy` grouped away both and nothing touched missions. Ties break deterministically.
- The killer-name subquery is now built fresh per use instead of shared — a reused `*gorm.DB` accumulates state.
- The head panel's note used to carry "deadliest in…" and "reaches for…" sentences; those were a poor man's dossier and are gone.

## Verified against live data

- Blue AI, all time: F-16C (425 sorties) · AGM-154 JSOW (111 kills) · Su-24M (71 destroyed) · Buk launcher (47 losses) · Red AI (101 shoot-downs) · 9M38M1 (47 deaths — consistent with the launcher line) · Caucasus (91 kills).
- Mission scope: fallback weapon line renders, theatre correctly hidden.
- Meekss (no kills, no recorded takeoffs): panel hides itself entirely.
- No console errors; `go vet` and the graph/controllers tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)