### PR TITLE
Stop counting trees and rammings as combat performance

### DIFF
--- a/controllers/aggregates.go
+++ b/controllers/aggregates.go
@@ -21,6 +21,35 @@ import (
 // BY, and COUNT(*) FILTER is not portable, so conditional counts use
 // SUM(CASE WHEN ...).
 
+// notScenery excludes blast damage to trees, walls and houses. Written against
+// a LEFT JOIN, so an event with no target row at all still counts: the target
+// being unknown is not the same as it having been a tree.
+const notScenery = `(targets.kind IS NULL OR targets.kind <> 'scenery')`
+
+// isCollision recognises DCS naming an airframe as the weapon, which is how it
+// reports an aircraft flown into something.
+//
+// Type equality alone is not enough. A gun hit records the shell as both the
+// initiator object and the weapon, so a bare `initiator.type = weapon.type`
+// test files 17,624 M61 cannon hits in the current database as rammings. Real
+// stores are prefixed `weapons.` by DCS and airframes never are, which
+// separates the two cleanly.
+//
+// Requires the events query to alias units on the initiator as iunits.
+const isCollision = `(iunits.type = weapons.type AND weapons.type NOT LIKE 'weapons.%')`
+
+// sceneryUnitIDs selects every units row that has been seen as scenery.
+//
+// Unit rows carry no kind of their own -- a beech and a Hornet are both just a
+// type string -- so the only record of which is which is the kind stored on the
+// targets that referenced them. Built fresh per call, since a reused *gorm.DB
+// accumulates state.
+func sceneryUnitIDs() *gorm.DB {
+	return initializers.DB.Model(&models.Target{}).
+		Select("targets.unit_id").
+		Where("targets.kind = ?", models.ObjectKindScenery)
+}
+
 // scopeMission narrows an events-rooted query to one mission when set. Nil
 // means all of recorded history, which is what the API defaulted to before
 // missions existed, so existing callers keep their meaning.
@@ -248,6 +277,10 @@ func nestShotRows(rows []shotRow) []*models.PlayerShotBreakdown {
 // A teamkill only counts when both sides are known: two unknown coalitions
 // compare equal but say nothing about whose side anyone was on, and every event
 // recorded before coalition tracking existed is unknown.
+//
+// Scenery is excluded, like every other kill figure. It is the scoreboard on
+// the front page, and counting felled trees toward a coalition's total put 5%
+// of blue's and 7% of red's score down to woodland.
 func GetKillsByCoalition(missionID *uint) ([]*models.CoalitionKills, error) {
 	// Rows predating coalition tracking have an empty string rather than
 	// "unknown", so normalise before grouping.
@@ -261,7 +294,8 @@ func GetKillsByCoalition(missionID *uint) ([]*models.CoalitionKills, error) {
 			COUNT(*) AS kills,
 			SUM(CASE WHEN events.coalition <> '' AND events.coalition <> 'unknown'
 				AND events.target_coalition = events.coalition THEN 1 ELSE 0 END) AS teamkills`).
-		Where("events.event = ?", "kill").
+		Joins("LEFT JOIN targets ON targets.target_id = events.target_id").
+		Where("events.event = ? AND "+notScenery, "kill").
 		Group(coalitionExpr).
 		Order(coalitionExpr).
 		Scan(&rows).Error
@@ -283,6 +317,12 @@ func GetKillsByCoalition(missionID *uint) ([]*models.CoalitionKills, error) {
 // Hits and kills against scenery are excluded: DCS reports a blast catching a
 // tree as a hit, and counting those would inflate accuracy for anything with a
 // warhead. Shots have no target, so they are counted unconditionally.
+//
+// Collisions are counted separately rather than as hits and kills. DCS names
+// the airframe as the weapon when an aircraft is flown into something, so an
+// A-50 appears as a store with 142 kills to its name. Splitting them out keeps
+// the ratios about what the weapon did and gives the client a real number to
+// filter on instead of inferring collisions from an absent shot count.
 func GetWeaponEffectiveness(missionID *uint) ([]*models.WeaponEffectiveness, error) {
 	var rows []models.WeaponEffectiveness
 
@@ -291,11 +331,14 @@ func GetWeaponEffectiveness(missionID *uint) ([]*models.WeaponEffectiveness, err
 		Select(`weapons.type AS weapon_type,
 			SUM(CASE WHEN events.event = 'shot' THEN 1 ELSE 0 END) AS shots,
 			SUM(CASE WHEN events.event = 'hit'
-				AND (targets.kind IS NULL OR targets.kind <> 'scenery') THEN 1 ELSE 0 END) AS hits,
+				AND `+notScenery+` AND NOT `+isCollision+` THEN 1 ELSE 0 END) AS hits,
 			SUM(CASE WHEN events.event = 'kill'
-				AND (targets.kind IS NULL OR targets.kind <> 'scenery') THEN 1 ELSE 0 END) AS kills`).
+				AND `+notScenery+` AND NOT `+isCollision+` THEN 1 ELSE 0 END) AS kills,
+			SUM(CASE WHEN events.event IN ('hit','kill')
+				AND `+isCollision+` THEN 1 ELSE 0 END) AS collisions`).
 		Joins("JOIN weapons ON weapons.weapon_id = events.weapon_id").
 		Joins("LEFT JOIN targets ON targets.target_id = events.target_id").
+		Joins("LEFT JOIN units AS iunits ON iunits.unit_id = events.initiator_unit_id").
 		Where("events.event IN ?", []string{"shot", "hit", "kill"}).
 		Group("weapons.type").
 		Order("weapons.type").
@@ -552,18 +595,23 @@ func GetPlayerProfile(playerID uint, unitType string, missionID *uint) (*models.
 		view.Aircraft = append(view.Aircraft, &aircraft[i])
 	}
 
-	// Per weapon.
+	// Per weapon. Collisions are split out exactly as in
+	// GetWeaponEffectiveness, so a pilot's own airframe cannot be crowned
+	// their weapon of choice on the strength of what it rammed.
 	var weapons []models.WeaponEffectiveness
 	if err := onUnit(db.Model(&models.Event{})).
 		Scopes(scopeMission(missionID)).
 		Select(`weapons.type AS weapon_type,
 			SUM(CASE WHEN events.event = 'shot' THEN 1 ELSE 0 END) AS shots,
 			SUM(CASE WHEN events.event = 'hit'
-				AND (targets.kind IS NULL OR targets.kind <> 'scenery') THEN 1 ELSE 0 END) AS hits,
+				AND `+notScenery+` AND NOT `+isCollision+` THEN 1 ELSE 0 END) AS hits,
 			SUM(CASE WHEN events.event = 'kill'
-				AND (targets.kind IS NULL OR targets.kind <> 'scenery') THEN 1 ELSE 0 END) AS kills`).
+				AND `+notScenery+` AND NOT `+isCollision+` THEN 1 ELSE 0 END) AS kills,
+			SUM(CASE WHEN events.event IN ('hit','kill')
+				AND `+isCollision+` THEN 1 ELSE 0 END) AS collisions`).
 		Joins("JOIN weapons ON weapons.weapon_id = events.weapon_id").
 		Joins("LEFT JOIN targets ON targets.target_id = events.target_id").
+		Joins("LEFT JOIN units AS iunits ON iunits.unit_id = events.initiator_unit_id").
 		Where("events.player_id = ?", playerID).
 		Group("weapons.type").
 		Order("shots DESC, kills DESC, weapons.type").
@@ -1123,14 +1171,18 @@ func GetUnitProfile(unitType string) (*models.UnitProfileView, error) {
 		Sorties, Shots, Hits, Kills, Losses, Ejections int
 	}
 
+	// Scenery is excluded from hits and kills here as it is everywhere else.
+	// Without the guard an airframe's card credited it with every tree its
+	// bombs caught, which for a strike aircraft is most of its record.
 	err := initializers.DB.Model(&models.Event{}).
 		Select(`SUM(CASE WHEN events.event IN ('takeoff','runway_takeoff') THEN 1 ELSE 0 END) AS sorties,
 			SUM(CASE WHEN events.event = 'shot' THEN 1 ELSE 0 END) AS shots,
-			SUM(CASE WHEN events.event = 'hit' THEN 1 ELSE 0 END) AS hits,
-			SUM(CASE WHEN events.event = 'kill' THEN 1 ELSE 0 END) AS kills,
+			SUM(CASE WHEN events.event = 'hit' AND `+notScenery+` THEN 1 ELSE 0 END) AS hits,
+			SUM(CASE WHEN events.event = 'kill' AND `+notScenery+` THEN 1 ELSE 0 END) AS kills,
 			SUM(CASE WHEN events.event IN ('crash','dead','unit_lost','pilot_dead') THEN 1 ELSE 0 END) AS losses,
 			SUM(CASE WHEN events.event = 'ejection' THEN 1 ELSE 0 END) AS ejections`).
 		Joins("JOIN units ON units.unit_id = events.initiator_unit_id").
+		Joins("LEFT JOIN targets ON targets.target_id = events.target_id").
 		Where("units.type = ?", unitType).
 		Scan(&totals).Error
 	if err != nil {
@@ -1151,7 +1203,8 @@ func GetUnitProfile(unitType string) (*models.UnitProfileView, error) {
 	if err := initializers.DB.Model(&models.Event{}).
 		Joins("JOIN targets ON targets.target_id = events.target_id").
 		Joins("JOIN units ON units.unit_id = targets.unit_id").
-		Where("events.event = ? AND units.type = ?", "kill", unitType).
+		Where("events.event = ? AND units.type = ? AND targets.kind <> ?",
+			"kill", unitType, models.ObjectKindScenery).
 		Count(&killed).Error; err != nil {
 		logs.Sugar.Errorf("Failed to count losses for %q: %v", unitType, err)
 		return nil, err
@@ -1205,11 +1258,14 @@ func GetWeaponProfile(weaponType string) (*models.WeaponProfileView, error) {
 	err := initializers.DB.Model(&models.Event{}).
 		Select(`SUM(CASE WHEN events.event = 'shot' THEN 1 ELSE 0 END) AS shots,
 			SUM(CASE WHEN events.event = 'hit'
-				AND (targets.kind IS NULL OR targets.kind <> 'scenery') THEN 1 ELSE 0 END) AS hits,
+				AND `+notScenery+` AND NOT `+isCollision+` THEN 1 ELSE 0 END) AS hits,
 			SUM(CASE WHEN events.event = 'kill'
-				AND (targets.kind IS NULL OR targets.kind <> 'scenery') THEN 1 ELSE 0 END) AS kills`).
+				AND `+notScenery+` AND NOT `+isCollision+` THEN 1 ELSE 0 END) AS kills,
+			SUM(CASE WHEN events.event IN ('hit','kill')
+				AND `+isCollision+` THEN 1 ELSE 0 END) AS collisions`).
 		Joins("JOIN weapons ON weapons.weapon_id = events.weapon_id").
 		Joins("LEFT JOIN targets ON targets.target_id = events.target_id").
+		Joins("LEFT JOIN units AS iunits ON iunits.unit_id = events.initiator_unit_id").
 		Where("weapons.type = ?", weaponType).
 		Scan(&totals).Error
 	if err != nil {
@@ -1220,6 +1276,7 @@ func GetWeaponProfile(weaponType string) (*models.WeaponProfileView, error) {
 	view.Shots = totals.Shots
 	view.Hits = totals.Hits
 	view.Kills = totals.Kills
+	view.Collisions = totals.Collisions
 	view.HitsPerShot = totals.HitsPerShot()
 	view.KillsPerShot = totals.KillsPerShot()
 

--- a/controllers/lookups.go
+++ b/controllers/lookups.go
@@ -28,10 +28,20 @@ func GetPlayerByID(id string) (*models.Player, error) {
 	return firstOrNil[models.Player](initializers.DB.Where("player_id = ?", id))
 }
 
+// GetUnits lists the unit types worth showing: airframes and vehicles, not the
+// woodland they crashed into.
+//
+// Scenery and statics share the units table with real units, because DCS gives
+// both nothing but a type string. That is fine for storage and wrong for a
+// listing -- 197 of the 317 rows in the current database are beeches, cypresses
+// and houses -- so the scenery ones are filtered out here rather than left for
+// every caller to remember.
 func GetUnits() ([]*models.Unit, error) {
 	var units []*models.Unit
 
-	if err := initializers.DB.Order("unit_id").Find(&units).Error; err != nil {
+	if err := initializers.DB.
+		Where("unit_id NOT IN (?)", sceneryUnitIDs()).
+		Order("unit_id").Find(&units).Error; err != nil {
 		logs.Sugar.Errorf("Failed to list units: %v", err)
 		return nil, err
 	}

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -104,6 +104,8 @@ type WeaponProfile {
     shots: Int!
     hits: Int!
     kills: Int!
+    "Hits and kills where this airframe was rammed into something. See WeaponEffectiveness.collisions."
+    collisions: Int!
     hitsPerShot: Float!
     killsPerShot: Float!
     "Airframes and vehicles seen firing it, busiest first."
@@ -114,8 +116,17 @@ type WeaponProfile {
 type WeaponEffectiveness {
     weaponType: String!
     shots: Int!
+    "Excludes scenery and collisions."
     hits: Int!
+    "Excludes scenery and collisions."
     kills: Int!
+    """
+    Hits and kills where DCS named this airframe as the weapon, which is how it
+    reports an aircraft flown into something. Held apart from hits and kills so
+    the ratios stay about what a weapon does. A row with collisions and no shots
+    is a ramming record rather than a store.
+    """
+    collisions: Int!
     """
     Hits divided by shots. A ratio, not a percentage: it exceeds 1 for
     submunition and splash weapons, because DCS emits one shot event per launch
@@ -433,6 +444,7 @@ type LandingGrade {
 
 type CoalitionKills {
     coalition: String!
+    "Excludes scenery, like every other kill figure."
     kills: Int!
     teamkills: Int!
 }
@@ -543,6 +555,7 @@ type Query {
     event(id: ID!): Event
     players: [Player]
     player(id: ID!): Player
+    "Airframes and vehicles. Scenery types share the table and are filtered out."
     units: [Unit]
     unit(id: ID!): Unit
     weapons: [Weapon]

--- a/models/summary.go
+++ b/models/summary.go
@@ -13,6 +13,12 @@ type WeaponEffectiveness struct {
 	Shots      int
 	Hits       int
 	Kills      int
+	// Collisions are hits and kills where DCS named this airframe as the
+	// weapon, which is how it reports an aircraft flown into something. Kept
+	// out of Hits and Kills so the ratios stay about what a weapon does, and
+	// reported here so a row can be recognised as a collision rather than
+	// guessed at from having no shots.
+	Collisions int
 }
 
 // HitsPerShot is hits divided by shots. Deliberately a ratio rather than a
@@ -365,9 +371,12 @@ type WeaponProfileView struct {
 	Source   string
 	Specs    *Specs
 
-	Shots        int
-	Hits         int
-	Kills        int
+	Shots int
+	Hits  int
+	Kills int
+	// Collisions are hits and kills where this type was the airframe that did
+	// the ramming rather than a store that was fired. See WeaponEffectiveness.
+	Collisions   int
 	HitsPerShot  float64
 	KillsPerShot float64
 	// Carriers are the airframes seen firing it, busiest first.

--- a/web/app.js
+++ b/web/app.js
@@ -117,7 +117,7 @@ function dashQuery() {
   return `{
   missions { id name theatre startedAt events duration }
   killsByCoalition${p} { coalition kills teamkills }
-  weaponEffectiveness${p} { weaponType shots hits kills hitsPerShot killsPerShot }
+  weaponEffectiveness${p} { weaponType shots hits kills collisions hitsPerShot killsPerShot }
   playerActivity${p} { playerID playerName kills takeoffs landings crashes ejections deaths }
   landingGrades(first: 40${m ? ", " + m : ""}) { playerName unitType place grade missionTime }
   records${p} {
@@ -257,10 +257,15 @@ const playerHay = (n) => (n ? [n, playerLabel(n)] : []);
 
 // Guns report hits with no shot events; airframes appear as weapons when DCS
 // names the aircraft for a collision.
+//
+// Collisions come from the server now. The old rule here was "no shots, not a
+// gun, so it must be a ramming", which quietly mislabels any store whose shot
+// events were dropped upstream -- and shot events do get dropped, which is what
+// the DCS-gRPC patch is for.
 function storeClass(row) {
   if (row.weaponType.startsWith("weapons.shells.")) return "gun";
-  if (row.shots > 0) return "ordnance";
-  return "collision";
+  if (row.collisions > 0 && row.shots === 0) return "collision";
+  return "ordnance";
 }
 
 // A name that opens a reference card. The DCS identifier travels in a data
@@ -408,11 +413,16 @@ function drawHero(d) {
 
 function drawWeapons(rows) {
   const filtered = rows
-    .filter((r) => r.shots || r.hits || r.kills)
+    .filter((r) => r.shots || r.hits || r.kills || r.collisions)
     .filter((r) => state.weaponClass === "all" || storeClass(r) === state.weaponClass)
     .filter((r) => matches(weaponHay(r.weaponType)));
 
   const max = Math.max(1, ...filtered.map((r) => r.shots));
+
+  // The collisions column earns its width only when something in view has one.
+  // A ramming record is otherwise a row of zeroes, since collisions are held
+  // out of hits and kills.
+  const showCollisions = filtered.some((r) => r.collisions > 0);
 
   render(
     "weapons",
@@ -421,6 +431,7 @@ function drawWeapons(rows) {
       { label: "Shots", key: "shots", num: true },
       { label: "Hits", key: "hits", num: true },
       { label: "Kills", key: "kills", num: true },
+      ...(showCollisions ? [{ label: "Collisions", key: "collisions", num: true }] : []),
       { label: "Hits / shot", key: "hitsPerShot", num: true },
       { label: "Kills / shot", key: "killsPerShot", num: true },
     ],
@@ -432,6 +443,7 @@ function drawWeapons(rows) {
       }</td>
       <td class="num">${num(r.hits)}</td>
       <td class="num">${num(r.kills)}</td>
+      ${showCollisions ? `<td class="num">${num(r.collisions)}</td>` : ""}
       <td class="num">${r.shots ? ratio(r.hitsPerShot) : `<span class="zero">—</span>`}</td>
       <td class="num">${r.shots ? ratio(r.killsPerShot) : `<span class="zero">—</span>`}</td>
     </tr>`
@@ -683,7 +695,7 @@ const PLAYER_QUERY = `query($id: ID!, $unitType: String, $m: ID) { playerProfile
   sorties landings crashes ejections deaths shots hits kills teamkills timesKilled
   killDeathRatio firstSeen lastSeen
   aircraft { unitType sorties landings shots hits kills losses ejections hitsPerShot killsPerShot }
-  weapons { weaponType shots hits kills hitsPerShot killsPerShot }
+  weapons { weaponType shots hits kills collisions hitsPerShot killsPerShot }
   matchups { unitType targetType kills }
   killedBy { unitType targetType kills }
   landingGrades { unitType place grade missionTime }
@@ -1326,6 +1338,9 @@ function drawPlayer() {
     drawPlayer
   );
 
+  const pWeapons = (p.weapons || []).filter((w) => matches(weaponHay(w.weaponType)));
+  const pCollisions = pWeapons.some((w) => w.collisions > 0);
+
   render(
     "p-weapons",
     [
@@ -1333,14 +1348,16 @@ function drawPlayer() {
       { label: "Shots", key: "shots", num: true },
       { label: "Hits", key: "hits", num: true },
       { label: "Kills", key: "kills", num: true },
+      ...(pCollisions ? [{ label: "Collisions", key: "collisions", num: true }] : []),
       { label: "Kills / shot", key: "killsPerShot", num: true },
     ],
-    sortRows((p.weapons || []).filter((w) => matches(weaponHay(w.weaponType))), "p-weapons"),
+    sortRows(pWeapons, "p-weapons"),
     (w) => `<tr>
       <td class="name">${ref("weapon", w.weaponType)}</td>
       <td class="num">${num(w.shots)}</td>
       <td class="num">${num(w.hits)}</td>
       <td class="num">${num(w.kills)}</td>
+      ${pCollisions ? `<td class="num">${num(w.collisions)}</td>` : ""}
       <td class="num">${w.shots ? ratio(w.killsPerShot) : `<span class="zero">—</span>`}</td>
     </tr>`,
     drawPlayer
@@ -1461,7 +1478,7 @@ const CARD_UNIT = `query($t: String!) { unitProfile(type: $t) {
 const CARD_WEAPON = `query($t: String!) { weaponProfile(type: $t) {
   type curated name nickname role origin maker blurb source
   specs { qid lengthM wingspanM heightM massKg firstFlight serviceEntry totalProduced makers }
-  shots hits kills hitsPerShot killsPerShot
+  shots hits kills collisions hitsPerShot killsPerShot
   carriers { unitType weapons { count } }
 } }`;
 
@@ -1591,6 +1608,7 @@ async function openCard(kind, type) {
           ${fact("shots", p.shots, true)}
           ${fact("hits", p.hits, true)}
           ${fact("kills", p.kills, true)}
+          ${p.collisions ? fact("collisions", p.collisions, true) : ""}
           ${fact("hits / shot", p.shots ? p.hitsPerShot.toFixed(2) : "—")}
           ${fact("kills / shot", p.shots ? p.killsPerShot.toFixed(2) : "—")}
         </dl>` +

--- a/web/index.html
+++ b/web/index.html
@@ -108,7 +108,8 @@
     <p class="note">
       Hits per shot is a ratio and can exceed 1 legitimately — DCS reports one shot per launch but one hit per
       object damaged, so cluster and splash weapons register several. Guns report hits and no shots, so they
-      have no ratio. Rows named after an aircraft are collisions, where DCS names the aircraft as the weapon.
+      have no ratio. Rows named after an aircraft are collisions, where DCS names the aircraft as the weapon;
+      those are counted apart from hits and kills so they do not flatter any weapon's figures.
     </p>
     <div class="tw"><table id="weapons" class="grid"></table></div>
   </section>


### PR DESCRIPTION
Closes #41. Closes #43.

Both issues had been *mostly* addressed already — scenery was filtered in about a dozen aggregates, and the dashboard had a Collisions filter chip. Auditing them against the live database turned up the places that were missed, and they were the ones that mattered most.

## Scenery (#41)

| Where | Was | Now |
|---|---|---|
| `killsByCoalition` — the front-page tug-of-war | blue 1097, red 1263 | blue 1041, red 1177 |
| `GetUnits` — backs the `units` query | 317 rows, 197 of them foliage | 120 rows, no foliage |
| `GetUnitProfile` hits/kills | every tree the airframe's bombs caught | combat only |
| `GetUnitProfile.timesKilled` | unguarded | excludes scenery targets |

5% of blue's score and 7% of red's was woodland; a third of the unattributed column was. `GetCollateral` still counts scenery deliberately — that is the joke shelf and it stays.

## Collisions (#43)

DCS names the airframe as the weapon when an aircraft is flown into something, so an A-50 showed up as a store with 142 kills and 807 hits. Collisions now get their own column and are held out of hits and kills, so hits-per-shot stays a statement about the weapon.

**The naive test does not work.** `initiator.type = weapon.type` also matches gun hits, because DCS records the shell as both the initiator object and the weapon — it files 17,624 M61 cannon hits as rammings. Real stores are prefixed `weapons.` and airframes never are, which separates them cleanly. Verified against the database: 34 collision rows, every one an airframe, zero gun rows caught.

The client was guessing at this with "no shots and not a gun ⇒ collision". That quietly mislabels any store whose shot events were dropped upstream, and shot events *do* get dropped — it is what the DCS-gRPC patch in #42 exists for. It now reads the server's count.

## UI

The Collisions column appears only when a row in view has one, since a ramming record is otherwise a row of zeroes. Same on the player page. Weapon reference cards show it when non-zero.

One regression caught during verification and fixed: the weapons table gates rows on `shots || hits || kills`, so collision rows — now zero on all three — vanished from the Collisions filter entirely. The gate includes collisions.

Verified in the browser: collision view lists 34 rows with the extra column, ordnance view drops the column, ratios read `—` where there are no shots, and the player page matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)