### PR TITLE
Harden the GraphQL endpoint short of authentication

### DIFF
--- a/routers/graphql.go
+++ b/routers/graphql.go
@@ -4,14 +4,33 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/lru"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/MartinHell/overlord/graph"
 	"github.com/MartinHell/overlord/graph/generated"
 	"github.com/MartinHell/overlord/logs"
 	"github.com/MartinHell/overlord/web"
+	"github.com/vektah/gqlparser/v2/ast"
 )
+
+// queryComplexityLimit caps how expensive one GraphQL query may be.
+//
+// Without it a caller can nest connections until the resolvers do unbounded
+// work -- the schema has no depth limit of its own, and every field is free to
+// ask. The number is generous next to what the dashboard sends: its heaviest
+// page load scores in the low hundreds, so this leaves room to grow while still
+// refusing anything pathological.
+const queryComplexityLimit = 2000
+
+// maxRequestBytes bounds a request body. A GraphQL query is a few kilobytes at
+// most; anything larger is either a mistake or an attempt to make the parser
+// work for its living.
+const maxRequestBytes = 1 << 20 // 1 MiB
 
 func GraphQLHandler() {
 	port := os.Getenv("PORT")
@@ -23,11 +42,34 @@ func GraphQLHandler() {
 	if environment == "" {
 		environment = "development"
 	}
+	development := environment != "production"
 
-	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
+	// Host to bind. Empty means every interface, which is what this has always
+	// done and what a container needs. Set HOST=127.0.0.1 to keep the API on
+	// the machine it runs on, which is the right setting for a dashboard beside
+	// a DCS server until there is authentication in front of it (see #36).
+	host := os.Getenv("HOST")
+
+	// Built explicitly rather than with NewDefaultServer, which mounts things
+	// this API does not have and should not offer: a websocket transport with
+	// no subscriptions in the schema, multipart form handling with no uploads,
+	// and introspection unconditionally.
+	srv := handler.New(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
+	srv.AddTransport(transport.Options{})
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+	srv.SetQueryCache(lru.New[*ast.QueryDocument](1000))
+	srv.Use(extension.FixedComplexityLimit(queryComplexityLimit))
+
+	// Introspection is what lets a client discover the whole schema. The
+	// playground needs it; nothing else here does, so the two are gated
+	// together.
+	if development {
+		srv.Use(extension.Introspection{})
+	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/query", srv)
+	mux.Handle("/query", http.MaxBytesHandler(srv, maxRequestBytes))
 
 	// Health endpoint for container probes. Deliberately separate from anything
 	// that renders, so it stays valid whatever else is or is not mounted.
@@ -71,17 +113,52 @@ func GraphQLHandler() {
 
 	// The playground moves off / now that the dashboard lives there. It stays
 	// out of production entirely: it is an unauthenticated query console.
-	if environment != "production" {
+	if development {
 		mux.Handle("/playground", playground.Handler("GraphQL Playground", "/query"))
 	}
 
+	// No CORS headers are sent, and that is the policy rather than an
+	// oversight: without them a browser refuses to hand another origin's page
+	// the response, which is the correct answer for an API that has no
+	// authentication yet. Adding permissive CORS would remove the one control
+	// currently doing any work.
+
 	logs.Sugar.Infof("Dashboard available at http://localhost:%s/", port)
 	logs.Sugar.Infof("GraphQL API listening on http://localhost:%s/query", port)
-	if environment != "production" {
+	if development {
 		logs.Sugar.Infof("GraphQL playground available at http://localhost:%s/playground", port)
 	}
 
-	if err := http.ListenAndServe(":"+port, mux); err != nil {
+	// Say plainly what is exposed. The API has no authentication, so binding
+	// every interface publishes the whole database to anything that can route
+	// to this machine. That may be exactly what is wanted on a trusted LAN, but
+	// it should be a decision rather than a surprise.
+	if !isLoopback(host) {
+		logs.Sugar.Warnf(
+			"GraphQL API is reachable from the network on %s:%s with no authentication. "+
+				"Set HOST=127.0.0.1 to restrict it to this machine.",
+			displayHost(host), port)
+	}
+
+	if err := http.ListenAndServe(host+":"+port, mux); err != nil {
 		logs.Sugar.Fatal(err)
 	}
+}
+
+// isLoopback reports whether a bind host keeps the listener on this machine.
+// An empty host is every interface, which is the permissive case.
+func isLoopback(host string) bool {
+	switch strings.ToLower(strings.Trim(host, "[]")) {
+	case "127.0.0.1", "::1", "localhost":
+		return true
+	default:
+		return false
+	}
+}
+
+func displayHost(host string) string {
+	if host == "" {
+		return "all interfaces"
+	}
+	return host
 }


### PR DESCRIPTION
Addresses the parts of #36 that are engineering rather than product decisions. **Leaves #36 open** for the auth model itself, which is the part that needs your call (see below).

## What changed

The server is now built explicitly rather than by `handler.NewDefaultServer`, which mounts a websocket transport for a schema with no subscriptions, multipart form handling with no uploads, and introspection unconditionally.

| Control | Before | After |
|---|---|---|
| Query complexity | unlimited | 2000 |
| Request body | unlimited | 1 MiB |
| Introspection | always on | shares the playground's gate |
| Playground | on unless `ENVIRONMENT=production` | unchanged |
| Bind address | always all interfaces | `HOST` env, default unchanged |
| Exposure warning | none | logged when not on loopback |

The complexity limit matters because the schema has no depth limit of its own — anyone reaching the port could nest connections until the resolvers did unbounded work. 2000 is generous: the dashboard's heaviest page load scores in the low hundreds.

`HOST` defaults to empty, i.e. every interface, so **nothing about the current deployment changes**. Setting `HOST=127.0.0.1` restricts it, which is the right setting for a dashboard sitting beside a DCS server until there is auth in front.

## CORS stays absent, deliberately

Now with a comment saying so. Without CORS headers a browser refuses to hand another origin's page the response — which is the correct answer for an API with no authentication. Adding permissive CORS would remove the one control currently doing any work.

## Verified

- Complexity: 600 aliased copies of a query → `operation has complexity 2400, which exceeds the limit of 2000`. Normal queries unaffected.
- `ENVIRONMENT=production`: introspection returns `introspection disabled`, `/playground` returns 404, real queries still serve.
- `HOST=127.0.0.1`: `Get-NetTCPConnection` confirms it listens on `127.0.0.1` rather than `0.0.0.0`, and the exposure warning correctly does not fire.
- Default start: warning fires, dashboard and player pages load normally.

## Still open on #36

Authentication, and the admin role that #49 names as a hard blocker for the live map. That needs two answers only you can give: whether admins are identified by DCS UCID or by independent web accounts, and whether the API gets a shared token or real per-user sessions. I have not guessed at either.

Also unaddressed and still true: overlord sends no client token to DCS-gRPC, so running that listener on anything other than `127.0.0.1` leaves it unauthenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)