### PR TITLE
Let the kill maps play the mission back

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -1149,3 +1149,37 @@ tr.first-place .name a { color: var(--gold); }
 .opp-name { flex: 1 1 8rem; font-weight: 600; }
 .opp-stat { color: var(--text-dim); font-variant-numeric: tabular-nums; }
 .opp-stat b { color: var(--text); font-weight: 600; }
+
+/* ---- map replay scrubber ---- */
+.scrub {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  margin-top: 0.6rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+}
+.scrub[hidden] { display: none; }
+.scrub-play {
+  flex: none;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.8125rem;
+  line-height: 1;
+}
+.scrub-range {
+  flex: 1 1 auto;
+  min-width: 0;
+  accent-color: var(--gold);
+  cursor: pointer;
+}
+.scrub-clock {
+  flex: none;
+  color: var(--text-dim);
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+}

--- a/web/app.js
+++ b/web/app.js
@@ -1038,6 +1038,8 @@ function collateralPanel(c, scope) {
 let killMap = null;
 let killLayer = null;
 let killMapFitted = false;
+// Held so the replay can re-plot without another fetch.
+let killPts = [];
 
 // Most kills name nothing: DCS fires the event after it has already
 // deallocated the victim, so about two thirds of them arrive with coordinates
@@ -1046,6 +1048,109 @@ let killMapFitted = false;
 // tell a confirmed victim from an anonymous one.
 const targetLabel = (t) => (t ? unitName(t) : "unknown target");
 const targetOpacity = (t) => (t ? 0.6 : 0.28);
+
+// ---- map replay -----------------------------------------------------------
+
+// Both kill maps can play the mission back. Every dot already carries a mission
+// clock, so this is a filter over points that are on the page already: no track
+// sampling, no new table, no StreamUnits.
+//
+// Offered in mission scope only. Across all time the clock restarts with every
+// mission, so one slider would interleave forty of them into nonsense.
+const SCRUB_STEPS = 140; // frames in a full playthrough
+const SCRUB_FRAME_MS = 110; // ~15s end to end, whatever the mission's length
+
+const scrubs = {};
+
+function scrubFor(id, replot) {
+  let s = scrubs[id];
+  if (!s) {
+    s = scrubs[id] = { max: 0, at: Infinity, playing: false, timer: null, replot };
+    wireScrub(id, s);
+  }
+  s.replot = replot;
+  return s;
+}
+
+function wireScrub(id, s) {
+  const wrap = el(id + "-scrub");
+  if (!wrap) return;
+
+  wrap.querySelector(".scrub-range").addEventListener("input", (e) => {
+    stopScrub(s);
+    s.at = Number(e.target.value);
+    paintScrub(id, s);
+    s.replot();
+  });
+  wrap.querySelector(".scrub-play").addEventListener("click", () => toggleScrub(id, s));
+}
+
+function toggleScrub(id, s) {
+  if (s.playing) {
+    stopScrub(s);
+    paintScrub(id, s);
+    return;
+  }
+  // Pressing play at the end restarts, rather than doing nothing.
+  if (s.at >= s.max) s.at = 0;
+  s.playing = true;
+  paintScrub(id, s);
+  s.replot();
+
+  s.timer = setInterval(() => {
+    s.at = Math.min(s.max, s.at + s.max / SCRUB_STEPS);
+    if (s.at >= s.max) stopScrub(s);
+    paintScrub(id, s);
+    s.replot();
+  }, SCRUB_FRAME_MS);
+}
+
+function stopScrub(s) {
+  s.playing = false;
+  if (s.timer) clearInterval(s.timer);
+  s.timer = null;
+}
+
+function paintScrub(id, s) {
+  const wrap = el(id + "-scrub");
+  if (!wrap) return;
+
+  const range = wrap.querySelector(".scrub-range");
+  range.max = Math.max(1, Math.round(s.max));
+  range.value = Math.round(Math.min(s.at, s.max));
+
+  const play = wrap.querySelector(".scrub-play");
+  play.textContent = s.playing ? "⏸" : "▶";
+  play.setAttribute("aria-label", s.playing ? "Pause the replay" : "Play the mission back");
+  wrap.querySelector(".scrub-clock").textContent = clock(Math.min(s.at, s.max));
+}
+
+// Fit the scrubber to the points in hand and report the current cutoff.
+//
+// A live mission keeps growing. Someone parked at the end should stay at the
+// end as new kills arrive; someone who scrubbed back to watch an engagement
+// should not be yanked forward every fifteen seconds.
+function scrubCutoff(id, points, replot) {
+  const wrap = el(id + "-scrub");
+  const perMission = state.scope === "mission";
+  const worth = perMission && points.length > 1;
+  if (wrap) wrap.hidden = !worth;
+
+  const s = scrubFor(id, replot);
+  if (!worth) {
+    stopScrub(s);
+    s.at = Infinity;
+    return Infinity;
+  }
+
+  const max = Math.max(...points.map((p) => p.missionTime || 0));
+  const wasAtEnd = s.at >= s.max;
+  s.max = max;
+  if (wasAtEnd) s.at = max;
+  paintScrub(id, s);
+
+  return s.at;
+}
 
 function drawKillMap(points) {
   const host = el("killmap");
@@ -1067,16 +1172,34 @@ function drawKillMap(points) {
     killLayer = L.layerGroup().addTo(killMap);
   }
 
-  killLayer.clearLayers();
-
-  const pts = points || [];
-  if (!pts.length) {
+  killPts = points || [];
+  if (!killPts.length) {
+    killLayer.clearLayers();
     host.classList.add("map-empty");
+    const wrap = el("killmap-scrub");
+    if (wrap) wrap.hidden = true;
     return;
   }
   host.classList.remove("map-empty");
 
-  for (const p of pts) {
+  scrubCutoff("killmap", killPts, plotKillPoints);
+  plotKillPoints();
+
+  // Framed on every point, not the visible ones, so the view holds still
+  // while the replay runs.
+  if (!killMapFitted) {
+    killMap.fitBounds(L.latLngBounds(killPts.map((p) => [p.lat, p.lon])).pad(0.2));
+    killMapFitted = true;
+  }
+}
+
+function plotKillPoints() {
+  if (!killLayer) return;
+  killLayer.clearLayers();
+
+  const cut = scrubs.killmap ? scrubs.killmap.at : Infinity;
+  for (const p of killPts) {
+    if ((p.missionTime || 0) > cut) continue;
     L.circleMarker([p.lat, p.lon], {
       radius: 5,
       weight: 1,
@@ -1089,11 +1212,6 @@ function drawKillMap(points) {
       )
       .addTo(killLayer);
   }
-
-  if (!killMapFitted) {
-    killMap.fitBounds(L.latLngBounds(pts.map((p) => [p.lat, p.lon])).pad(0.2));
-    killMapFitted = true;
-  }
 }
 
 // The mission map: both sides' kills, coloured by coalition. Same rules as
@@ -1101,6 +1219,7 @@ function drawKillMap(points) {
 let missionMap = null;
 let missionLayer = null;
 let missionMapFitted = false;
+let missionPts = [];
 
 const SIDE_FILL = { blue: "#2563c9", red: "#c0382e" };
 
@@ -1124,16 +1243,32 @@ function drawMissionMap(points) {
     missionLayer = L.layerGroup().addTo(missionMap);
   }
 
-  missionLayer.clearLayers();
-
-  const pts = points || [];
-  if (!pts.length) {
+  missionPts = points || [];
+  if (!missionPts.length) {
+    missionLayer.clearLayers();
     host.classList.add("map-empty");
+    const wrap = el("missionmap-scrub");
+    if (wrap) wrap.hidden = true;
     return;
   }
   host.classList.remove("map-empty");
 
-  for (const p of pts) {
+  scrubCutoff("missionmap", missionPts, plotMissionPoints);
+  plotMissionPoints();
+
+  if (!missionMapFitted) {
+    missionMap.fitBounds(L.latLngBounds(missionPts.map((p) => [p.lat, p.lon])).pad(0.2));
+    missionMapFitted = true;
+  }
+}
+
+function plotMissionPoints() {
+  if (!missionLayer) return;
+  missionLayer.clearLayers();
+
+  const cut = scrubs.missionmap ? scrubs.missionmap.at : Infinity;
+  for (const p of missionPts) {
+    if ((p.missionTime || 0) > cut) continue;
     L.circleMarker([p.lat, p.lon], {
       radius: 5,
       weight: 1,
@@ -1146,11 +1281,6 @@ function drawMissionMap(points) {
           `${esc(targetLabel(p.targetType))}${p.weaponType ? " · " + esc(weaponName(p.weaponType)) : ""} · ${clock(p.missionTime)}`
       )
       .addTo(missionLayer);
-  }
-
-  if (!missionMapFitted) {
-    missionMap.fitBounds(L.latLngBounds(pts.map((p) => [p.lat, p.lon])).pad(0.2));
-    missionMapFitted = true;
   }
 }
 
@@ -1770,6 +1900,12 @@ function schedule() {
 document.addEventListener("visibilitychange", () => {
   if (document.hidden) {
     clearInterval(timer);
+    // A replay running in a tab nobody is looking at is the same waste, and
+    // it would be most of the way through by the time they came back.
+    for (const id of Object.keys(scrubs)) {
+      stopScrub(scrubs[id]);
+      paintScrub(id, scrubs[id]);
+    }
   } else if (el("live").checked) {
     tick();
     schedule();

--- a/web/index.html
+++ b/web/index.html
@@ -95,6 +95,14 @@
       the time the event fired. The position is real; only the victim is anonymous.
     </p>
     <div id="missionmap"></div>
+    <!-- Replay. Every dot already carries a mission clock, so playing the
+         mission back is a filter rather than a new data source. -->
+    <div class="scrub" id="missionmap-scrub" hidden>
+      <button type="button" class="scrub-play" aria-label="Play the mission back">▶</button>
+      <input type="range" class="scrub-range" min="0" max="100" value="100" step="1"
+             aria-label="Mission time">
+      <span class="scrub-clock" aria-live="off">--:--:--</span>
+    </div>
   </section>
 
   <section class="card-panel" id="p-weapons">

--- a/web/player.html
+++ b/web/player.html
@@ -88,6 +88,13 @@
       the time the event fired. The position is real; only the victim is anonymous.
     </p>
     <div id="killmap"></div>
+    <!-- Replay; see index.html. -->
+    <div class="scrub" id="killmap-scrub" hidden>
+      <button type="button" class="scrub-play" aria-label="Play the mission back">▶</button>
+      <input type="range" class="scrub-range" min="0" max="100" value="100" step="1"
+             aria-label="Mission time">
+      <span class="scrub-clock" aria-live="off">--:--:--</span>
+    </div>
   </section>
 
   <div class="split">


### PR DESCRIPTION
Drag the slider, or hit play, and the mission unfolds across the map.

The nice part is what this *doesn't* need. Every kill point already carries `missionTime`, so this is a filter over data that was already on the page — **no track sampling, no new table, no `StreamUnits`, no schema change.** The expensive version of this (#51) is a whole subsystem with a retention policy; this is a slider.

## Behaviour

- Play walks from zero to the mission's last event in ~15s **whatever its real length**, so a 4-hour session and a 20-minute one both watch at a comfortable pace.
- Dragging takes over and stops playback. Pressing play at the end restarts from zero rather than doing nothing.
- **Mission scope only.** Across all time the clock restarts with every mission, so one slider would interleave 40 of them into nonsense — the control hides itself and every dot stays put.

Two things it has to get right while a mission is live:

- Someone parked at the end **follows** the end as new kills arrive; someone who scrubbed back to watch an engagement is **left where they are** rather than yanked forward every 15 seconds.
- The map frame is fitted to *every* point, not the visible ones, so the view holds still during playback instead of zooming into the first kill.

Replays stop when the tab is hidden, for the same reason polling does — it would otherwise be most of the way through by the time you looked back.

## Verified in the browser

Mission map, current mission (76 kills over 49:46): scrub to 12:27 → 1 dot; back to the end → 76. Play advances 00:00:21 → 00:00:42 → 00:01:04 → 00:01:25 across frames with the icon flipping ⏸/▶ correctly. Switching to All time hides the control and restores all 2,000 dots. Player page behaves the same (53 dots at the end, 33 at the halfway mark). Gold accent applied, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)