### PR TITLE
Add a flight log of individual sorties

### DIFF
--- a/controllers/aggregates.go
+++ b/controllers/aggregates.go
@@ -792,6 +792,12 @@ func GetPlayerProfile(playerID uint, unitType string, missionID *uint) (*models.
 
 	view.Favourites = fav
 
+	sorties, err := GetSorties(playerID, missionID, unitType)
+	if err != nil {
+		return nil, err
+	}
+	view.SortieLog = sorties
+
 	// Graded landings, newest first.
 	var grades []models.LandingGrade
 	if err := db.Model(&models.Event{}).

--- a/controllers/sorties.go
+++ b/controllers/sorties.go
@@ -42,6 +42,24 @@ const (
 // mergeWindow generously covers the observed gaps of 11s and 31s.
 const mergeWindow = 90.0
 
+// killGrace keeps a flight open to its own last shots. Missiles in the air when
+// an aircraft dies still score, and DCS timestamps those kills a fraction after
+// the death event, so they would otherwise fall into the gap between flights.
+const killGrace = 10.0
+
+// sameAirframe decides whether a kill belongs to the flight in hand.
+//
+// The window a kill lands in is not enough on its own. DCS names an airframe on
+// the kill event too, and the two genuinely disagree in the recorded data: one
+// kill is stamped F-15ESE seventy seconds before that pilot took off in an
+// F-15ESE, while they were still in a Viggen. Requiring both to agree keeps the
+// flight log saying the same thing as the aircraft table and the titles, which
+// count by the airframe DCS named. A kill neither can place is left uncounted
+// rather than pinned on the wrong aeroplane.
+func sameAirframe(killed, flown string) bool {
+	return killed == "" || flown == "" || killed == flown
+}
+
 func sortieFamily(event string) string {
 	switch event {
 	case "takeoff", "runway_takeoff":
@@ -125,6 +143,10 @@ func GetSorties(playerID uint, missionID *uint, unitType string) ([]*models.Sort
 
 	var out []*models.Sortie
 	var open *models.Sortie
+	// The flight that just ended, kept briefly so its last shots can still
+	// land against it. See killGrace.
+	var justClosed *models.Sortie
+	justClosedAt := 0.0
 
 	// close finishes the flight in hand. Called for every terminal event and
 	// again when a fresh takeoff arrives with one still open, which is what a
@@ -142,6 +164,7 @@ func GetSorties(playerID uint, missionID *uint, unitType string) ([]*models.Sort
 			}
 		}
 		out = append(out, open)
+		justClosed, justClosedAt = open, at
 		open = nil
 	}
 
@@ -170,8 +193,12 @@ func GetSorties(playerID uint, missionID *uint, unitType string) ([]*models.Sort
 		if r.Event == "kill" {
 			// Kills before the first takeoff belong to no flight -- a ground
 			// unit, or a sortie whose takeoff went unrecorded.
-			if open != nil {
-				open.Kills++
+			s := open
+			if s == nil && justClosed != nil && r.MissionTime-justClosedAt <= killGrace {
+				s = justClosed
+			}
+			if s != nil && sameAirframe(r.UnitType, s.UnitType) {
+				s.Kills++
 			}
 			continue
 		}

--- a/controllers/sorties.go
+++ b/controllers/sorties.go
@@ -1,0 +1,256 @@
+package controllers
+
+import (
+	"sort"
+	"time"
+
+	"github.com/MartinHell/overlord/initializers"
+	"github.com/MartinHell/overlord/logs"
+	"github.com/MartinHell/overlord/models"
+)
+
+// Sorties, derived from the event stream.
+//
+// A sortie is the span between a takeoff and whatever ended it. The events
+// already say that exactly, in order, so this walks them rather than keeping a
+// sorties table in step with them. See models.Sortie for the reasoning.
+//
+// Deliberately not offered for the synthetic AI players: their events are every
+// AI unit on a coalition pooled under one id, so "the sortie between this
+// takeoff and the next landing" would splice together aircraft that never met.
+
+// maxSorties caps the log that reaches a page. Newest first, so the cap drops
+// the oldest flights rather than the interesting ones.
+const maxSorties = 40
+
+// DCS reports one physical event several times over. A single departure arrives
+// as runway_takeoff and then takeoff eleven seconds later; one arrival as
+// runway_touch and then land, thirty-one seconds apart; one loss as pilot_dead,
+// unit_lost and crash on the same timestamp. Taken literally that turns four
+// flights into eight, half of them eleven seconds long and ending in "unknown".
+//
+// So repeats of a family inside a short window count as the one thing that
+// happened. Nothing else can fall inside that window: a touch and go puts a
+// departure between the two arrivals, and a departure ends any flight still
+// open, so consecutive same-family reports really are duplicates.
+const (
+	famDepart = "depart"
+	famArrive = "arrive"
+	famEnd    = "end"
+)
+
+// mergeWindow generously covers the observed gaps of 11s and 31s.
+const mergeWindow = 90.0
+
+func sortieFamily(event string) string {
+	switch event {
+	case "takeoff", "runway_takeoff":
+		return famDepart
+	case "land", "runway_touch":
+		return famArrive
+	case "crash", "pilot_dead", "unit_lost", "dead", "ejection":
+		return famEnd
+	}
+	return ""
+}
+
+// endOutcome ranks the several ways DCS describes one loss. Ejecting is the
+// most specific thing that can be said about it -- the pilot got out -- and a
+// crash says more than the bare fact of dying, so they win over the rest.
+func endOutcome(event string) (string, int) {
+	switch event {
+	case "ejection":
+		return models.SortieEjected, 3
+	case "crash":
+		return models.SortieCrashed, 2
+	default:
+		return models.SortieKilled, 1
+	}
+}
+
+// sortieEvent is one row of the walk: the events that open, close or fill a
+// flight, in the order DCS reported them.
+type sortieEvent struct {
+	ID          uint
+	Event       string
+	MissionID   *uint
+	MissionTime float64
+	UnitType    string
+	CreatedAt   time.Time
+}
+
+// GetSorties reconstructs a player's flights, newest first.
+func GetSorties(playerID uint, missionID *uint, unitType string) ([]*models.Sortie, error) {
+	var player models.Player
+	if err := initializers.DB.Where("player_id = ?", playerID).First(&player).Error; err != nil {
+		logs.Sugar.Errorf("Failed to load player %d for sorties: %v", playerID, err)
+		return nil, nil
+	}
+	if models.IsAIPlayerName(player.GetPlayerName()) {
+		return nil, nil
+	}
+
+	var rows []sortieEvent
+	if err := initializers.DB.Model(&models.Event{}).
+		Scopes(scopeMission(missionID)).
+		Select(`events.id AS id,
+			events.event AS event,
+			events.mission_id AS mission_id,
+			events.mission_time AS mission_time,
+			units.type AS unit_type,
+			events.created_at AS created_at`).
+		Joins("LEFT JOIN units ON units.unit_id = events.initiator_unit_id").
+		Joins("LEFT JOIN targets ON targets.target_id = events.target_id").
+		Where("events.player_id = ? AND events.event IN ?", playerID, []string{
+			"takeoff", "runway_takeoff",
+			"land", "runway_touch",
+			"crash", "pilot_dead", "ejection", "unit_lost", "dead",
+			"kill",
+		}).
+		Where("events.event <> 'kill' OR "+notScenery).
+		Order("events.id").
+		Scan(&rows).Error; err != nil {
+		logs.Sugar.Errorf("Failed to load sortie events for player %d: %v", playerID, err)
+		return nil, err
+	}
+
+	missions, err := GetMissions()
+	if err != nil {
+		return nil, err
+	}
+	missionByID := map[uint]*models.MissionSummary{}
+	for _, m := range missions {
+		missionByID[m.MissionID] = m
+	}
+
+	var out []*models.Sortie
+	var open *models.Sortie
+
+	// close finishes the flight in hand. Called for every terminal event and
+	// again when a fresh takeoff arrives with one still open, which is what a
+	// missing landing looks like.
+	close := func(outcome string, at float64) {
+		if open == nil {
+			return
+		}
+		if outcome != "" {
+			open.Outcome = outcome
+			open.Ended = true
+			open.EndTime = at
+			if at > open.StartTime {
+				open.Duration = at - open.StartTime
+			}
+		}
+		out = append(out, open)
+		open = nil
+	}
+
+	// State for collapsing repeat reports of one event.
+	lastFam := ""
+	lastFamAt := 0.0
+	var lastMission *uint
+	endRank := 0
+
+	sameEventAgain := func(fam string, r sortieEvent) bool {
+		if fam != lastFam || fam == "" {
+			return false
+		}
+		if r.MissionTime-lastFamAt > mergeWindow {
+			return false
+		}
+		if (r.MissionID == nil) != (lastMission == nil) {
+			return false
+		}
+		return r.MissionID == nil || *r.MissionID == *lastMission
+	}
+
+	for _, r := range rows {
+		fam := sortieFamily(r.Event)
+
+		if r.Event == "kill" {
+			// Kills before the first takeoff belong to no flight -- a ground
+			// unit, or a sortie whose takeoff went unrecorded.
+			if open != nil {
+				open.Kills++
+			}
+			continue
+		}
+
+		if sameEventAgain(fam, r) {
+			// The same thing, said again. The only thing a repeat can still
+			// tell us is a better word for how a flight ended.
+			if fam == famEnd && len(out) > 0 {
+				if name, rank := endOutcome(r.Event); rank > endRank {
+					endRank = rank
+					out[len(out)-1].Outcome = name
+				}
+			}
+			continue
+		}
+
+		lastFam, lastFamAt, lastMission = fam, r.MissionTime, r.MissionID
+
+		switch fam {
+		case famDepart:
+			// A departure with a flight still open means whatever ended the
+			// last one was never recorded. Better an honest "unknown" than
+			// folding two flights into one.
+			close(models.SortieUnknown, r.MissionTime)
+			endRank = 0
+
+			s := &models.Sortie{
+				UnitType:  r.UnitType,
+				StartTime: r.MissionTime,
+				Outcome:   models.SortieUnknown,
+				StartedAt: r.CreatedAt,
+			}
+			if r.MissionID != nil {
+				s.MissionID = *r.MissionID
+				if m := missionByID[*r.MissionID]; m != nil {
+					s.MissionName = m.Name
+					s.Theatre = m.Theatre
+				}
+			}
+			open = s
+
+		case famArrive:
+			close(models.SortieLanded, r.MissionTime)
+			endRank = 0
+
+		case famEnd:
+			name, rank := endOutcome(r.Event)
+			endRank = rank
+			close(name, r.MissionTime)
+		}
+	}
+
+	// A flight still open at the end of the events is exactly that: the pilot
+	// is up, or the recording stopped before they came down. It is listed, not
+	// invented an ending for.
+	if open != nil {
+		out = append(out, open)
+	}
+
+	// Newest first, and narrowed to one airframe when the page is.
+	filtered := out[:0]
+	for _, s := range out {
+		if unitType != "" && s.UnitType != unitType {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	out = filtered
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].MissionID != out[j].MissionID {
+			return out[i].MissionID > out[j].MissionID
+		}
+		return out[i].StartTime > out[j].StartTime
+	})
+
+	if len(out) > maxSorties {
+		out = out[:maxSorties]
+	}
+
+	return out, nil
+}

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -64,6 +64,9 @@ models:
   PlayerAircraftStats:
     model:
       - github.com/MartinHell/overlord/models.PlayerAircraftStats
+  Sortie:
+    model:
+      - github.com/MartinHell/overlord/models.Sortie
   Favourite:
     model:
       - github.com/MartinHell/overlord/models.Favourite

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -295,6 +295,11 @@ func (r *sceneryCountResolver) DisplayName(ctx context.Context, obj *models.Scen
 	return models.SceneryName(obj.Type), nil
 }
 
+// MissionID is the resolver for the missionID field.
+func (r *sortieResolver) MissionID(ctx context.Context, obj *models.Sortie) (string, error) {
+	return fmt.Sprintf("%v", obj.MissionID), nil
+}
+
 // TargetID is the resolver for the targetID field.
 func (r *targetResolver) TargetID(ctx context.Context, obj *models.Target) (string, error) {
 	return fmt.Sprintf("%v", obj.TargetID), nil
@@ -383,6 +388,9 @@ func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 // SceneryCount returns generated.SceneryCountResolver implementation.
 func (r *Resolver) SceneryCount() generated.SceneryCountResolver { return &sceneryCountResolver{r} }
 
+// Sortie returns generated.SortieResolver implementation.
+func (r *Resolver) Sortie() generated.SortieResolver { return &sortieResolver{r} }
+
 // Target returns generated.TargetResolver implementation.
 func (r *Resolver) Target() generated.TargetResolver { return &targetResolver{r} }
 
@@ -410,6 +418,7 @@ type (
 	playerShotBreakdownResolver struct{ *Resolver }
 	queryResolver               struct{ *Resolver }
 	sceneryCountResolver        struct{ *Resolver }
+	sortieResolver              struct{ *Resolver }
 	targetResolver              struct{ *Resolver }
 	unitResolver                struct{ *Resolver }
 	unitWeaponBreakdownResolver struct{ *Resolver }

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -208,6 +208,40 @@ type PlayerProfile {
 
     "The dossier superlatives: favourite aircraft, worst enemy and so on."
     favourites: Favourites!
+
+    """
+    Recent flights, newest first, capped at forty. Empty for the synthetic AI
+    players: their events pool every AI unit on a coalition, so the span between
+    one takeoff and the next landing would splice together aircraft that never
+    met.
+    """
+    sortieLog: [Sortie!]!
+}
+
+"""
+One flight: wheels up, what it did, and how it ended.
+
+Derived from the ordered events rather than stored, so every flight ever
+recorded has one and there is no table to drift out of step.
+"""
+type Sortie {
+    missionID: ID!
+    "Empty for runs recorded before mission names were captured."
+    missionName: String!
+    theatre: String!
+    "The airframe, when the takeoff event named one."
+    unitType: String!
+    "Mission clock at wheels up, in seconds."
+    startTime: Float!
+    "Mission clock at the end. Meaningless while ended is false."
+    endTime: Float!
+    "Seconds airborne. Zero for a flight that never ended."
+    duration: Float!
+    kills: Int!
+    "How it finished: landed, crashed, ejected, killed, or unknown."
+    outcome: String!
+    "False while the flight is still open — still up, or the recording stopped first."
+    ended: Boolean!
 }
 
 "One superlative: a name and how often it earned the title."

--- a/models/summary.go
+++ b/models/summary.go
@@ -1,9 +1,49 @@
 package models
 
+import "time"
+
 type UnitWeaponBreakdown struct {
 	Unit    string
 	Weapons []*WeaponShotBreakdown
 }
+
+// Sortie is one flight: wheels up, what happened, and how it ended.
+//
+// Derived from the event stream rather than stored. A sortie is the span
+// between a takeoff and whatever ended it, which the ordered events already
+// describe exactly -- there is nothing a sorties table would know that the
+// events do not. Deriving also means every flight ever recorded has a card,
+// with no backfill and no risk of the table drifting from the events it was
+// built from. If per-sortie attribution is ever wanted on the events
+// themselves, that is when the column earns its place.
+type Sortie struct {
+	MissionID   uint
+	MissionName string
+	Theatre     string
+	// UnitType is the airframe, when the takeoff event named one.
+	UnitType string
+	// StartTime and EndTime are the mission clock, in seconds.
+	StartTime float64
+	EndTime   float64
+	// Duration is zero for a sortie that never ended.
+	Duration float64
+	Kills    int
+	// Outcome is how the flight finished: landed, crashed, ejected, killed,
+	// or unknown when nothing closed it out.
+	Outcome string
+	// Ended is false while the flight is still open -- the pilot is up, or
+	// the recording stopped before they came down.
+	Ended     bool
+	StartedAt time.Time
+}
+
+const (
+	SortieLanded  = "landed"
+	SortieCrashed = "crashed"
+	SortieEjected = "ejected"
+	SortieKilled  = "killed"
+	SortieUnknown = "unknown"
+)
 
 // WeaponEffectiveness is shots against hits against kills for one weapon type.
 // Recording hits is what makes this possible at all: without them there is no
@@ -111,6 +151,9 @@ type PlayerProfileView struct {
 	KillPoints []*KillPoint
 
 	Favourites *Favourites
+	// SortieLog is the pilot's recent flights, newest first. Empty for the
+	// synthetic AI players, whose events pool every unit on a coalition.
+	SortieLog []*Sortie
 }
 
 // Favourite is one superlative: a name, how often it earned the title, and a

--- a/web/app.css
+++ b/web/app.css
@@ -1183,3 +1183,38 @@ tr.first-place .name a { color: var(--gold); }
   font-size: 0.8125rem;
   font-variant-numeric: tabular-nums;
 }
+
+/* ---- flight log ---- */
+.sorties { margin: 0; padding: 0; list-style: none; display: grid; gap: 0.4rem; }
+.sortie {
+  display: grid;
+  grid-template-columns: minmax(7rem, 1fr) auto;
+  align-items: baseline;
+  gap: 0.15rem 0.8rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  border-left: 3px solid var(--line-strong);
+  font-size: 0.8125rem;
+}
+.sortie-air { font-weight: 600; }
+.sortie-meta { grid-column: 1; color: var(--text-dim); }
+.sortie-kills { grid-column: 2; grid-row: 2; color: var(--text-dim); font-variant-numeric: tabular-nums; }
+.sortie-end {
+  grid-column: 2;
+  grid-row: 1;
+  justify-self: end;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+/* The outcome carries the only colour on the row, so a run of bad days reads
+   at a glance without turning the panel into a traffic light. */
+.sortie-landed { border-left-color: #3f9a5f; }
+.sortie-landed .sortie-end { color: #3f9a5f; }
+.sortie-ejected { border-left-color: #c9931f; }
+.sortie-ejected .sortie-end { color: #c9931f; }
+.sortie-crashed, .sortie-killed { border-left-color: #c0382e; }
+.sortie-crashed .sortie-end, .sortie-killed .sortie-end { color: #c0382e; }
+.sortie-unknown .sortie-end { color: var(--text-faint); }

--- a/web/app.css
+++ b/web/app.css
@@ -1149,3 +1149,37 @@ tr.first-place .name a { color: var(--gold); }
 .opp-name { flex: 1 1 8rem; font-weight: 600; }
 .opp-stat { color: var(--text-dim); font-variant-numeric: tabular-nums; }
 .opp-stat b { color: var(--text); font-weight: 600; }
+
+/* ---- map replay scrubber ---- */
+.scrub {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  margin-top: 0.6rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+}
+.scrub[hidden] { display: none; }
+.scrub-play {
+  flex: none;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.8125rem;
+  line-height: 1;
+}
+.scrub-range {
+  flex: 1 1 auto;
+  min-width: 0;
+  accent-color: var(--gold);
+  cursor: pointer;
+}
+.scrub-clock {
+  flex: none;
+  color: var(--text-dim);
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+}

--- a/web/app.js
+++ b/web/app.js
@@ -733,12 +733,59 @@ async function refreshLog() {
 
 // --- player page -----------------------------------------------------------
 
+// How a flight ended, as a word and a colour. Unknown is its own outcome and
+// says so: DCS simply never reported what happened, and guessing "landed"
+// would be worse than admitting it.
+const OUTCOME_LABEL = {
+  landed: "Landed",
+  crashed: "Crashed",
+  ejected: "Ejected",
+  killed: "Shot down",
+  unknown: "Unclear",
+};
+
+// A duration in words. Reads better than a clock for a span: nobody thinks of
+// a flight as 00:31:20.
+function dur(seconds) {
+  const s = Math.max(0, Math.round(seconds));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${String(s % 60).padStart(2, "0")}s`;
+  return `${Math.floor(m / 60)}h ${String(m % 60).padStart(2, "0")}m`;
+}
+
+// The flight log. One line per sortie: what was flown, how long it lasted,
+// what it got, and how it ended.
+function drawSorties(log) {
+  const panel = el("p-sorties");
+  if (!panel) return;
+
+  const rows = log.filter((s) => matches(unitHay(s.unitType)));
+  panel.hidden = !rows.length;
+  if (!rows.length) return;
+
+  el("sorties").innerHTML = rows
+    .map((s) => {
+      const outcome = OUTCOME_LABEL[s.outcome] || s.outcome;
+      const where = s.missionName || `Mission ${s.missionID}`;
+      const length = s.ended ? dur(s.duration) : "still up";
+      return `<li class="sortie sortie-${esc(s.outcome)}">
+        <span class="sortie-air">${ref("unit", s.unitType)}</span>
+        <span class="sortie-meta">${esc(where)}${s.theatre ? " · " + esc(s.theatre) : ""} · ${esc(length)}</span>
+        <span class="sortie-kills">${s.kills ? `${s.kills} ${s.kills === 1 ? "kill" : "kills"}` : ""}</span>
+        <span class="sortie-end">${esc(outcome)}</span>
+      </li>`;
+    })
+    .join("");
+}
+
 const PLAYER_QUERY = `query($id: ID!, $unitType: String, $m: ID) { playerProfile(playerID: $id, unitType: $unitType, missionID: $m) {
   playerID playerName isAI unitType flown coalitions
   sorties landings crashes ejections deaths shots hits kills teamkills timesKilled
   killDeathRatio firstSeen lastSeen
   aircraft { unitType sorties landings shots hits kills losses ejections hitsPerShot killsPerShot }
   weapons { weaponType shots hits kills collisions hitsPerShot killsPerShot }
+  sortieLog { missionID missionName theatre unitType startTime duration kills outcome ended }
   matchups { unitType targetType kills }
   killedBy { unitType targetType kills }
   landingGrades { unitType place grade missionTime }
@@ -1439,6 +1486,7 @@ function drawPlayer() {
     : "";
 
   drawDossier(p);
+  drawSorties(p.sortieLog || []);
 
   // Filter and per-model page are the same control. These are real links, so a
   // narrowed view is as shareable as the pilot's own page.

--- a/web/app.js
+++ b/web/app.js
@@ -1038,6 +1038,8 @@ function collateralPanel(c, scope) {
 let killMap = null;
 let killLayer = null;
 let killMapFitted = false;
+// Held so the replay can re-plot without another fetch.
+let killPts = [];
 
 // Most kills name nothing: DCS fires the event after it has already
 // deallocated the victim, so about two thirds of them arrive with coordinates
@@ -1046,6 +1048,109 @@ let killMapFitted = false;
 // tell a confirmed victim from an anonymous one.
 const targetLabel = (t) => (t ? unitName(t) : "unknown target");
 const targetOpacity = (t) => (t ? 0.6 : 0.28);
+
+// ---- map replay -----------------------------------------------------------
+
+// Both kill maps can play the mission back. Every dot already carries a mission
+// clock, so this is a filter over points that are on the page already: no track
+// sampling, no new table, no StreamUnits.
+//
+// Offered in mission scope only. Across all time the clock restarts with every
+// mission, so one slider would interleave forty of them into nonsense.
+const SCRUB_STEPS = 140; // frames in a full playthrough
+const SCRUB_FRAME_MS = 110; // ~15s end to end, whatever the mission's length
+
+const scrubs = {};
+
+function scrubFor(id, replot) {
+  let s = scrubs[id];
+  if (!s) {
+    s = scrubs[id] = { max: 0, at: Infinity, playing: false, timer: null, replot };
+    wireScrub(id, s);
+  }
+  s.replot = replot;
+  return s;
+}
+
+function wireScrub(id, s) {
+  const wrap = el(id + "-scrub");
+  if (!wrap) return;
+
+  wrap.querySelector(".scrub-range").addEventListener("input", (e) => {
+    stopScrub(s);
+    s.at = Number(e.target.value);
+    paintScrub(id, s);
+    s.replot();
+  });
+  wrap.querySelector(".scrub-play").addEventListener("click", () => toggleScrub(id, s));
+}
+
+function toggleScrub(id, s) {
+  if (s.playing) {
+    stopScrub(s);
+    paintScrub(id, s);
+    return;
+  }
+  // Pressing play at the end restarts, rather than doing nothing.
+  if (s.at >= s.max) s.at = 0;
+  s.playing = true;
+  paintScrub(id, s);
+  s.replot();
+
+  s.timer = setInterval(() => {
+    s.at = Math.min(s.max, s.at + s.max / SCRUB_STEPS);
+    if (s.at >= s.max) stopScrub(s);
+    paintScrub(id, s);
+    s.replot();
+  }, SCRUB_FRAME_MS);
+}
+
+function stopScrub(s) {
+  s.playing = false;
+  if (s.timer) clearInterval(s.timer);
+  s.timer = null;
+}
+
+function paintScrub(id, s) {
+  const wrap = el(id + "-scrub");
+  if (!wrap) return;
+
+  const range = wrap.querySelector(".scrub-range");
+  range.max = Math.max(1, Math.round(s.max));
+  range.value = Math.round(Math.min(s.at, s.max));
+
+  const play = wrap.querySelector(".scrub-play");
+  play.textContent = s.playing ? "⏸" : "▶";
+  play.setAttribute("aria-label", s.playing ? "Pause the replay" : "Play the mission back");
+  wrap.querySelector(".scrub-clock").textContent = clock(Math.min(s.at, s.max));
+}
+
+// Fit the scrubber to the points in hand and report the current cutoff.
+//
+// A live mission keeps growing. Someone parked at the end should stay at the
+// end as new kills arrive; someone who scrubbed back to watch an engagement
+// should not be yanked forward every fifteen seconds.
+function scrubCutoff(id, points, replot) {
+  const wrap = el(id + "-scrub");
+  const perMission = state.scope === "mission";
+  const worth = perMission && points.length > 1;
+  if (wrap) wrap.hidden = !worth;
+
+  const s = scrubFor(id, replot);
+  if (!worth) {
+    stopScrub(s);
+    s.at = Infinity;
+    return Infinity;
+  }
+
+  const max = Math.max(...points.map((p) => p.missionTime || 0));
+  const wasAtEnd = s.at >= s.max;
+  s.max = max;
+  if (wasAtEnd) s.at = max;
+  paintScrub(id, s);
+
+  return s.at;
+}
 
 function drawKillMap(points) {
   const host = el("killmap");
@@ -1067,16 +1172,34 @@ function drawKillMap(points) {
     killLayer = L.layerGroup().addTo(killMap);
   }
 
-  killLayer.clearLayers();
-
-  const pts = points || [];
-  if (!pts.length) {
+  killPts = points || [];
+  if (!killPts.length) {
+    killLayer.clearLayers();
     host.classList.add("map-empty");
+    const wrap = el("killmap-scrub");
+    if (wrap) wrap.hidden = true;
     return;
   }
   host.classList.remove("map-empty");
 
-  for (const p of pts) {
+  scrubCutoff("killmap", killPts, plotKillPoints);
+  plotKillPoints();
+
+  // Framed on every point, not the visible ones, so the view holds still
+  // while the replay runs.
+  if (!killMapFitted) {
+    killMap.fitBounds(L.latLngBounds(killPts.map((p) => [p.lat, p.lon])).pad(0.2));
+    killMapFitted = true;
+  }
+}
+
+function plotKillPoints() {
+  if (!killLayer) return;
+  killLayer.clearLayers();
+
+  const cut = scrubs.killmap ? scrubs.killmap.at : Infinity;
+  for (const p of killPts) {
+    if ((p.missionTime || 0) > cut) continue;
     L.circleMarker([p.lat, p.lon], {
       radius: 5,
       weight: 1,
@@ -1089,11 +1212,6 @@ function drawKillMap(points) {
       )
       .addTo(killLayer);
   }
-
-  if (!killMapFitted) {
-    killMap.fitBounds(L.latLngBounds(pts.map((p) => [p.lat, p.lon])).pad(0.2));
-    killMapFitted = true;
-  }
 }
 
 // The mission map: both sides' kills, coloured by coalition. Same rules as
@@ -1101,6 +1219,7 @@ function drawKillMap(points) {
 let missionMap = null;
 let missionLayer = null;
 let missionMapFitted = false;
+let missionPts = [];
 
 const SIDE_FILL = { blue: "#2563c9", red: "#c0382e" };
 
@@ -1124,16 +1243,32 @@ function drawMissionMap(points) {
     missionLayer = L.layerGroup().addTo(missionMap);
   }
 
-  missionLayer.clearLayers();
-
-  const pts = points || [];
-  if (!pts.length) {
+  missionPts = points || [];
+  if (!missionPts.length) {
+    missionLayer.clearLayers();
     host.classList.add("map-empty");
+    const wrap = el("missionmap-scrub");
+    if (wrap) wrap.hidden = true;
     return;
   }
   host.classList.remove("map-empty");
 
-  for (const p of pts) {
+  scrubCutoff("missionmap", missionPts, plotMissionPoints);
+  plotMissionPoints();
+
+  if (!missionMapFitted) {
+    missionMap.fitBounds(L.latLngBounds(missionPts.map((p) => [p.lat, p.lon])).pad(0.2));
+    missionMapFitted = true;
+  }
+}
+
+function plotMissionPoints() {
+  if (!missionLayer) return;
+  missionLayer.clearLayers();
+
+  const cut = scrubs.missionmap ? scrubs.missionmap.at : Infinity;
+  for (const p of missionPts) {
+    if ((p.missionTime || 0) > cut) continue;
     L.circleMarker([p.lat, p.lon], {
       radius: 5,
       weight: 1,
@@ -1146,11 +1281,6 @@ function drawMissionMap(points) {
           `${esc(targetLabel(p.targetType))}${p.weaponType ? " · " + esc(weaponName(p.weaponType)) : ""} · ${clock(p.missionTime)}`
       )
       .addTo(missionLayer);
-  }
-
-  if (!missionMapFitted) {
-    missionMap.fitBounds(L.latLngBounds(pts.map((p) => [p.lat, p.lon])).pad(0.2));
-    missionMapFitted = true;
   }
 }
 
@@ -1770,6 +1900,12 @@ function schedule() {
 document.addEventListener("visibilitychange", () => {
   if (document.hidden) {
     clearInterval(timer);
+    // A replay running in a tab nobody is looking at is the same waste, and
+    // it would be most of the way through by the time they came back.
+    for (const id of Object.keys(scrubs)) {
+      stopScrub(scrubs[id]);
+      paintScrub(id, scrubs[id]);
+    }
   } else if (el("live").checked) {
     tick();
     schedule();

--- a/web/index.html
+++ b/web/index.html
@@ -95,6 +95,14 @@
       the time the event fired. The position is real; only the victim is anonymous.
     </p>
     <div id="missionmap"></div>
+    <!-- Replay. Every dot already carries a mission clock, so playing the
+         mission back is a filter rather than a new data source. -->
+    <div class="scrub" id="missionmap-scrub" hidden>
+      <button type="button" class="scrub-play" aria-label="Play the mission back">▶</button>
+      <input type="range" class="scrub-range" min="0" max="100" value="100" step="1"
+             aria-label="Mission time">
+      <span class="scrub-clock" aria-live="off">--:--:--</span>
+    </div>
   </section>
 
   <section class="card-panel" id="p-weapons">

--- a/web/player.html
+++ b/web/player.html
@@ -88,6 +88,13 @@
       the time the event fired. The position is real; only the victim is anonymous.
     </p>
     <div id="killmap"></div>
+    <!-- Replay; see index.html. -->
+    <div class="scrub" id="killmap-scrub" hidden>
+      <button type="button" class="scrub-play" aria-label="Play the mission back">▶</button>
+      <input type="range" class="scrub-range" min="0" max="100" value="100" step="1"
+             aria-label="Mission time">
+      <span class="scrub-clock" aria-live="off">--:--:--</span>
+    </div>
   </section>
 
   <div class="split">

--- a/web/player.html
+++ b/web/player.html
@@ -69,6 +69,13 @@
     <dl id="dossier" class="dossier"></dl>
   </section>
 
+  <!-- The flight log. Hidden for the AI, whose events pool a whole coalition. -->
+  <section class="card-panel" id="p-sorties" hidden>
+    <div class="phead"><h2>Flight log</h2></div>
+    <p class="note">Each flight from wheels up to whatever ended it, newest first.</p>
+    <ol id="sorties" class="sorties"></ol>
+  </section>
+
   <section class="card-panel" id="p-badges">
     <div class="phead"><h2>Badges</h2></div>
     <p class="note">Career achievements, across every mission. Locked ones show how close you are.</p>


### PR DESCRIPTION
Closes the sortie half of #32 — see below for why without a table.

Career totals make a poor story when the career is four kills. A flight log makes a better one:

```
F/A-18C Hornet    Kolkhi_Test · Caucasus · 4m 38s              CRASHED
F-15ESE           Kolkhi_Test · Caucasus · 19s                 CRASHED
AJS 37 Viggen     Kolkhi_Test · Caucasus · 4m 59s · 1 kill     CRASHED
F-16C Block 50    Kolkhi_Test · Caucasus · 31m 20s · 1 kill    LANDED
```

## Derived, not stored

A sortie is the span between a takeoff and whatever ended it — which the ordered events already describe exactly. A `sorties` table would know nothing the events do not, so this walks them instead. That means every flight ever recorded gets a card with no backfill and no migration, and there is no table that can drift out of step with the events it was built from.

If per-sortie attribution is ever wanted **on the events themselves**, that is when `events.sortie_id` earns its place. It is not needed for this.

## DCS reports everything two or three times

This was the real work. A single departure arrives as `runway_takeoff` **and then** `takeoff` eleven seconds later. One arrival is `runway_touch` then `land`, thirty-one seconds apart. One loss is `pilot_dead`, `unit_lost` and `crash` on the same timestamp.

Read literally, Meekss's four flights became eight — every real sortie shadowed by an eleven-second phantom ending in "unknown":

```
m37  FA-18C_hornet  start 1212.0   278s  -> crashed
m37  FA-18C_hornet  start 1212.0    11s  -> unknown     <- phantom
```

Repeats of a family inside a 90s window now count as one event. Nothing legitimate can fall inside that window: a touch-and-go puts a departure between two arrivals, and a departure closes any open flight. Where a loss is described several ways, the most specific word wins — ejecting over crashing over simply dying.

## Not for the AI

The synthetic AI players pool every AI unit on a coalition under one id, so "the span between this takeoff and the next landing" would splice together aircraft that never met. The panel stays hidden for them.

Verified against the raw event stream: 4 departures, 1 landing, 3 losses in the database produce exactly 4 flights with matching times, durations, kill counts and outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)