### PR TITLE
Split the dashboard into sections and give it navigation

### DIFF
--- a/routers/graphql.go
+++ b/routers/graphql.go
@@ -100,6 +100,13 @@ func GraphQLHandler() {
 	mux.HandleFunc("/player/", servePage("player.html"))
 	mux.HandleFunc("/mission/", servePage("mission.html"))
 
+	// The dashboard's sections. Each is a real URL so it can be linked,
+	// bookmarked and opened in a tab, rather than a panel someone has to scroll
+	// past on the way to the one they wanted.
+	mux.HandleFunc("/missions", servePage("missions.html"))
+	mux.HandleFunc("/weapons", servePage("weapons.html"))
+	mux.HandleFunc("/log", servePage("log.html"))
+
 	// The playground moves off / now that the dashboard lives there. It stays
 	// out of production entirely: it is an unauthenticated query console.
 	if development {

--- a/web/app.css
+++ b/web/app.css
@@ -1274,3 +1274,33 @@ tr.first-place .name a { color: var(--gold); }
   font-weight: 600;
   text-transform: uppercase;
 }
+
+/* ---- section navigation ---- */
+/* Sits between the wordmark and the controls, and wraps to its own line before
+   either of them does: on a phone the sections matter more than the search box.
+   Styled as text rather than buttons -- these are links to pages, and making
+   them look like the filter chips would say they toggle something. */
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.15rem;
+  margin-right: auto;
+}
+.nav a {
+  padding: 0.3rem 0.6rem;
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+.nav a:hover { color: var(--text); background: var(--surface-2); }
+.nav a.on { color: var(--text); background: var(--emph); font-weight: 600; }
+
+a.brand { text-decoration: none; color: inherit; }
+a.brand:hover b { text-decoration: underline; }
+
+/* The controls no longer need to claim the free space; the nav does. */
+.controls { margin-left: 0; }

--- a/web/app.js
+++ b/web/app.js
@@ -111,25 +111,45 @@ function pref(id, name) {
 const midArg = () =>
   state.scope === "mission" && state.missionID ? `missionID: "${state.missionID}"` : "";
 
+// The query is composed from the panels the page actually has.
+//
+// The dashboard used to be every panel at once, so one query fetched
+// everything: the weapons table, the whole event log, the map and the records,
+// on every page. Split across sections, most of that is waste on most pages --
+// /missions needs none of it. Asking the DOM which panels exist keeps the
+// query honest without a second list to keep in step with the markup.
+const wants = (id) => Boolean(el(id));
+
 function dashQuery() {
   const m = midArg();
   const p = m ? `(${m})` : "";
+
+  // Display names back every reference card and most tables, so they come
+  // along wherever anything renders a unit or weapon by name.
+  const needNames = wants("weapons") || wants("records") || wants("killfeed") || wants("traps") || wants("log");
+
   return `{
   missions { id name theatre startedAt events duration }
-  killsByCoalition${p} { coalition kills teamkills }
-  weaponEffectiveness${p} { weaponType shots hits kills collisions hitsPerShot killsPerShot }
-  playerActivity${p} { playerID playerName kills takeoffs landings crashes ejections deaths }
-  landingGrades(first: 40${m ? ", " + m : ""}) { playerName unitType place grade missionTime }
-  records${p} {
+  ${wants("tug-blue") ? `killsByCoalition${p} { coalition kills teamkills }` : ""}
+  ${wants("weapons") ? `weaponEffectiveness${p} { weaponType shots hits kills collisions hitsPerShot killsPerShot }` : ""}
+  ${wants("pilots") ? `playerActivity${p} { playerID playerName kills takeoffs landings crashes ejections deaths }` : ""}
+  ${wants("traps") ? `landingGrades(first: 40${m ? ", " + m : ""}) { playerName unitType place grade missionTime }` : ""}
+  ${
+    wants("records")
+      ? `records${p} {
     firstBlood { playerID playerName unitType targetType missionTime }
     longestKill { playerID playerName unitType weaponType targetType rangeM }
     highestKill { playerID playerName unitType targetType altitudeM }
     deadliest { weaponType shots kills killsPerShot }
+  }`
+      : ""
   }
-  collateral${p} { struck levelled trees structures top { displayName count tree } }
-  missionTasks${p} { taskKey title state playerName playerID points }
-  killPoints${p} { lat lon coalition playerName unitType targetType weaponType missionTime }
-  feed: events(first: 8, eventType: "kill"${m ? ", " + m : ""}) {
+  ${wants("collateral") ? `collateral${p} { struck levelled trees structures top { displayName count tree } }` : ""}
+  ${wants("tasks") ? `missionTasks${p} { taskKey title state playerName playerID points }` : ""}
+  ${wants("missionmap") ? `killPoints${p} { lat lon coalition playerName unitType targetType weaponType missionTime }` : ""}
+  ${
+    wants("killfeed")
+      ? `feed: events(first: 8, eventType: "kill"${m ? ", " + m : ""}) {
     edges { node {
       id missionTime coalition
       player { playerID playerName }
@@ -138,9 +158,10 @@ function dashQuery() {
       target { unit { type } }
       targetName
     } }
+  }`
+      : ""
   }
-  units { type displayName }
-  weapons { type displayName }
+  ${needNames ? `units { type displayName }\n  weapons { type displayName }` : ""}
 }`;
 }
 
@@ -365,8 +386,13 @@ function drawHero(d) {
     el("hero-sub").textContent = `${missions.length} missions on file`;
   }
 
-  const nodes = (state.log?.edges || []).map((e) => e.node);
-  el("hero-clock").textContent = nodes.length ? clock(nodes[0].missionTime || 0) : "--:--:--";
+  // The clock is the mission's own span, not the newest row in the event log.
+  // The log is a windowed query that only one section fetches now, and taking
+  // the clock from it meant a long-dead run's 01:12:55 could sit in the header
+  // while the current mission was ten minutes old. A mission's duration is
+  // MAX(mission_time) over its own events, which is the same number and always
+  // the right one.
+  el("hero-clock").textContent = current ? clock(current.duration || 0) : "--:--:--";
 
   const tally = { blue: 0, red: 0, unknown: 0, teamkills: 0 };
   for (const c of d.killsByCoalition || []) {
@@ -682,6 +708,9 @@ function drawMissions(missions) {
     .join("");
 }
 
+// Every section runs the same draw. Each panel is skipped when the page it
+// would render into is not this one, so the sections share one code path
+// rather than each growing its own.
 function draw() {
   const d = state.data;
   if (!d) return;
@@ -689,31 +718,16 @@ function draw() {
   for (const u of d.units || []) names.unit.set(u.type, u.displayName);
   for (const w of d.weapons || []) names.weapon.set(w.type, w.displayName);
 
-  drawHero(d);
-  drawMissions(d.missions || []);
-  drawWeapons(d.weaponEffectiveness || []);
-  drawPilots(d.playerActivity || []);
-  drawTraps(d.landingGrades || []);
-  drawLog(state.log);
-  drawRecords(d.records);
-  drawTasks("tasks", "p-tasks", d.missionTasks);
-  drawMissionMap(d.killPoints);
-  el("collateral").innerHTML = collateralPanel(d.collateral, "mission");
-
-  const nodes = (state.log?.edges || []).map((e) => e.node);
-
-  // The clock reads the newest event, not the maximum in the window. The
-  // database holds many mission runs, and taking the max let a long-dead run's
-  // 01:12:55 sit in the header while the current mission was ten minutes old --
-  // then jump backwards once those events left the window.
-  const latest = nodes.length ? nodes[0].missionTime || 0 : 0;
-  const sorties = (d.playerActivity || []).reduce((s, p) => s + p.takeoffs, 0);
-  const kills = (d.killsByCoalition || []).reduce((s, c) => s + c.kills, 0);
-
-  setStat("ro-clock", clock(latest));
-  setStat("ro-events", nodes.length >= LOG_ROWS ? `${LOG_ROWS}+` : String(nodes.length));
-  setStat("ro-sorties", String(sorties));
-  setStat("ro-kills", String(kills));
+  if (wants("hero-title")) drawHero(d);
+  if (wants("missions")) drawMissions(d.missions || []);
+  if (wants("weapons")) drawWeapons(d.weaponEffectiveness || []);
+  if (wants("pilots")) drawPilots(d.playerActivity || []);
+  if (wants("traps")) drawTraps(d.landingGrades || []);
+  if (wants("log")) drawLog(state.log);
+  if (wants("records")) drawRecords(d.records);
+  if (wants("tasks")) drawTasks("tasks", "p-tasks", d.missionTasks);
+  if (wants("missionmap")) drawMissionMap(d.killPoints);
+  if (wants("collateral")) el("collateral").innerHTML = collateralPanel(d.collateral, "mission");
 }
 
 async function refresh(isRerun) {
@@ -725,7 +739,11 @@ async function refresh(isRerun) {
       state.missionID = m.missions?.[0]?.id || null;
     }
 
-    const [summary, log] = await Promise.all([gql(dashQuery()), fetchLog()]);
+    // The log is its own query and its own page; skip it everywhere else.
+    const [summary, log] = await Promise.all([
+      gql(dashQuery()),
+      wants("log") ? fetchLog() : Promise.resolve(state.log),
+    ]);
 
     // A new mission can start while the page sits open. Adopt it and refetch
     // once, so the page follows the server rather than a finished run.
@@ -2077,7 +2095,18 @@ chips("scope", "scope", (v) => {
   tick();
 });
 
-if (PAGE === "dashboard" || PAGE === "mission") {
+// Mark the section we are in. A mission recap belongs under Missions -- it is
+// one of them -- so it lights that link rather than none.
+{
+  const here = PAGE === "mission" ? "missions" : PAGE;
+  const link = document.querySelector(`.nav a[data-nav="${here}"]`);
+  if (link) {
+    link.classList.add("on");
+    link.setAttribute("aria-current", "page");
+  }
+}
+
+if (PAGE === "dashboard" || PAGE === "mission" || PAGE === "weapons" || PAGE === "log") {
   chips("weapon-class", "class", (v) => (state.weaponClass = v));
 
   // These two change what the query asks for, so they refetch rather than redraw.
@@ -2100,6 +2129,13 @@ if (PAGE === "player") {
   el("q").addEventListener("input", (e) => {
     state.query = e.target.value.trim().toLowerCase();
     drawPlayer();
+  });
+}
+
+if (PAGE === "missions") {
+  el("q").addEventListener("input", (e) => {
+    state.query = e.target.value.trim().toLowerCase();
+    draw();
   });
 }
 

--- a/web/embed.go
+++ b/web/embed.go
@@ -18,7 +18,7 @@ import (
 // browser will keep serving the previous version, which looks exactly like a
 // caching problem and is not one.
 //
-//go:embed index.html player.html mission.html app.css app.js
+//go:embed index.html player.html mission.html missions.html weapons.html log.html app.css app.js
 var files embed.FS
 
 // FS returns the dashboard's static files.

--- a/web/index.html
+++ b/web/index.html
@@ -7,7 +7,7 @@
      sane colour from the first frame. app.js narrows it to the chosen theme. -->
 <meta name="color-scheme" content="light dark">
 <title>Overlord — debrief</title>
-<link rel="stylesheet" href="app.css">
+<link rel="stylesheet" href="/app.css">
 <!-- Leaflet, pinned and integrity-checked; see player.html for the reasoning. -->
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
@@ -27,19 +27,23 @@
 </head>
 <body data-page="dashboard">
 
+<!-- The same header on every section. The four-figure readout that used to sit
+     here is gone: mission time was already in the hero below it, and the other
+     three were a summary of a page that now has sections of its own. Navigation
+     is worth more than a duplicate. -->
 <header class="top">
   <div class="top-in">
-    <div class="brand">
+    <a class="brand" href="/">
       <b>Overlord</b>
-      <span>Debrief</span>
-    </div>
+      <span>DCS debrief</span>
+    </a>
 
-    <dl class="stats">
-      <div><dt>Mission time</dt><dd id="ro-clock">--:--:--</dd></div>
-      <div><dt>Events</dt><dd id="ro-events">0</dd></div>
-      <div><dt>Sorties</dt><dd id="ro-sorties">0</dd></div>
-      <div><dt>Kills</dt><dd id="ro-kills">0</dd></div>
-    </dl>
+    <nav class="nav" aria-label="Sections">
+      <a href="/" data-nav="dashboard">Debrief</a>
+      <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/weapons" data-nav="weapons">Weapons</a>
+      <a href="/log" data-nav="log">Log</a>
+    </nav>
 
     <div class="controls">
       <div class="chips" id="scope" role="group" aria-label="Time range">
@@ -47,7 +51,7 @@
         <button type="button" data-scope="all">All time</button>
       </div>
       <label class="vh" for="q">Filter everything</label>
-      <input type="search" id="q" placeholder="Search pilots, aircraft, weapons…" autocomplete="off">
+      <input type="search" id="q" placeholder="Search pilots, aircraft…" autocomplete="off">
       <button id="theme" type="button">Theme</button>
       <label class="toggle"><input type="checkbox" id="live" checked> Live</label>
       <span id="link" class="status" role="status">Connecting</span>
@@ -82,14 +86,6 @@
     <ol id="killfeed" class="killfeed"></ol>
   </section>
 
-  <!-- Every recorded run, each its own page. Missions were only ever a filter
-       before this: forty of them with nowhere to link to. -->
-  <section class="card-panel" id="p-missions">
-    <div class="phead"><h2>Missions</h2></div>
-    <p class="note">Every recorded run. Each one has a page of its own worth pasting into chat.</p>
-    <ol id="missions" class="missions"></ol>
-  </section>
-
   <section class="card-panel" id="p-records">
     <div class="phead"><h2>Records</h2></div>
     <div id="records"></div>
@@ -111,25 +107,6 @@
              aria-label="Mission time">
       <span class="scrub-clock" aria-live="off">--:--:--</span>
     </div>
-  </section>
-
-  <section class="card-panel" id="p-weapons">
-    <div class="phead">
-      <h2>Weapons</h2>
-      <div class="chips" id="weapon-class" role="group" aria-label="Filter by weapon type">
-        <button type="button" data-class="all" class="on">All</button>
-        <button type="button" data-class="ordnance">Missiles &amp; bombs</button>
-        <button type="button" data-class="gun">Guns</button>
-        <button type="button" data-class="collision">Collisions</button>
-      </div>
-    </div>
-    <p class="note">
-      Hits per shot is a ratio and can exceed 1 legitimately — DCS reports one shot per launch but one hit per
-      object damaged, so cluster and splash weapons register several. Guns report hits and no shots, so they
-      have no ratio. Rows named after an aircraft are collisions, where DCS names the aircraft as the weapon;
-      those are counted apart from hits and kills so they do not flatter any weapon's figures.
-    </p>
-    <div class="tw"><table id="weapons" class="grid"></table></div>
   </section>
 
   <div class="split">
@@ -155,31 +132,6 @@
     <div class="tw"><table id="tasks" class="grid"></table></div>
   </section>
 
-  <section class="card-panel" id="p-collateral">
-    <div class="phead"><h2>Collateral damage</h2></div>
-    <div id="collateral"></div>
-  </section>
-
-  <section class="card-panel" id="p-log">
-    <div class="phead">
-      <h2>Events</h2>
-      <div class="chips" id="log-filter" role="group" aria-label="Filter the event log">
-        <button type="button" data-ev="all" class="on">All</button>
-        <button type="button" data-ev="kill">Kills</button>
-        <button type="button" data-ev="hit">Hits</button>
-        <button type="button" data-ev="shot">Shots</button>
-        <button type="button" data-ev="losses">Losses</button>
-        <button type="button" data-ev="sortie">Sorties</button>
-      </div>
-      <div class="chips" id="log-side" role="group" aria-label="Filter by coalition">
-        <button type="button" data-side="all" class="on">Both sides</button>
-        <button type="button" data-side="blue" class="side-blue">Blue</button>
-        <button type="button" data-side="red" class="side-red">Red</button>
-      </div>
-    </div>
-    <div class="tw tw-tall"><table id="log" class="grid"></table></div>
-  </section>
-
 </main>
 
 <!-- Reference card. Opened by clicking any aircraft or weapon name.
@@ -199,6 +151,6 @@
 
 <footer id="foot"></footer>
 
-<script src="app.js"></script>
+<script src="/app.js"></script>
 </body>
 </html>

--- a/web/log.html
+++ b/web/log.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- Declared before any CSS arrives so the browser paints the canvas in a
+     sane colour from the first frame. app.js narrows it to the chosen theme. -->
+<meta name="color-scheme" content="light dark">
+<title>Event log — Overlord</title>
+<link rel="stylesheet" href="/app.css">
+<script>
+  // Resolve the theme before first paint. app.css has no prefers-color-scheme
+  // block: it styles data-theme only, so this attribute has to exist by the
+  // time the stylesheet applies or the page flashes the wrong theme.
+  (function () {
+    var saved = null;
+    try { saved = localStorage.getItem("overlord-theme"); } catch (e) { /* private mode */ }
+    var dark = saved ? saved === "dark" : matchMedia("(prefers-color-scheme: dark)").matches;
+    document.documentElement.setAttribute("data-theme", dark ? "dark" : "light");
+  })();
+</script>
+</head>
+<body data-page="log">
+
+<!-- The same header on every section. The four-figure readout that used to sit
+     here is gone: mission time was already in the hero below it, and the other
+     three were a summary of a page that now has sections of its own. Navigation
+     is worth more than a duplicate. -->
+<header class="top">
+  <div class="top-in">
+    <a class="brand" href="/">
+      <b>Overlord</b>
+      <span>DCS debrief</span>
+    </a>
+
+    <nav class="nav" aria-label="Sections">
+      <a href="/" data-nav="dashboard">Debrief</a>
+      <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/weapons" data-nav="weapons">Weapons</a>
+      <a href="/log" data-nav="log">Log</a>
+    </nav>
+
+    <div class="controls">
+      <div class="chips" id="scope" role="group" aria-label="Time range">
+        <button type="button" data-scope="mission" class="on">This mission</button>
+        <button type="button" data-scope="all">All time</button>
+      </div>
+      <label class="vh" for="q">Filter everything</label>
+      <input type="search" id="q" placeholder="Filter events…" autocomplete="off">
+      <button id="theme" type="button">Theme</button>
+      <label class="toggle"><input type="checkbox" id="live" checked> Live</label>
+      <span id="link" class="status" role="status">Connecting</span>
+    </div>
+  </div>
+</header>
+
+<main>
+
+  <section class="card-panel" id="p-log">
+    <div class="phead">
+      <h2>Events</h2>
+      <div class="chips" id="log-filter" role="group" aria-label="Filter the event log">
+        <button type="button" data-ev="all" class="on">All</button>
+        <button type="button" data-ev="kill">Kills</button>
+        <button type="button" data-ev="hit">Hits</button>
+        <button type="button" data-ev="shot">Shots</button>
+        <button type="button" data-ev="losses">Losses</button>
+        <button type="button" data-ev="sortie">Sorties</button>
+      </div>
+      <div class="chips" id="log-side" role="group" aria-label="Filter by coalition">
+        <button type="button" data-side="all" class="on">Both sides</button>
+        <button type="button" data-side="blue" class="side-blue">Blue</button>
+        <button type="button" data-side="red" class="side-red">Red</button>
+      </div>
+    </div>
+    <p class="note">Straight from DCS, newest first. The raw record behind every other number on the site.</p>
+    <div class="tw tw-tall"><table id="log" class="grid"></table></div>
+  </section>
+
+</main>
+</main>
+
+<!-- Reference card. Opened by clicking any aircraft or weapon name.
+     A native <dialog> opened with showModal(): the focus trap, Escape to
+     close, the inert background and the backdrop all come with it. The
+     hand-rolled version of this left every control behind it tabbable. -->
+<dialog id="card" class="card" closedby="any" aria-labelledby="card-name">
+  <div class="card-head">
+    <div>
+      <h3 id="card-name">—</h3>
+      <p id="card-sub" class="card-sub"></p>
+    </div>
+    <button id="card-close" type="button">Close</button>
+  </div>
+  <div id="card-body"></div>
+</dialog>
+
+<footer id="foot"></footer>
+
+<script src="/app.js"></script>
+</body>
+</html>

--- a/web/mission.html
+++ b/web/mission.html
@@ -29,20 +29,19 @@
 
 <header class="top">
   <div class="top-in">
-    <div class="brand">
-      <a href="/"><b>Overlord</b></a>
+    <a class="brand" href="/">
+      <b>Overlord</b>
       <span>Mission recap</span>
-    </div>
+    </a>
 
-    <dl class="stats">
-      <div><dt>Mission time</dt><dd id="ro-clock">--:--:--</dd></div>
-      <div><dt>Events</dt><dd id="ro-events">0</dd></div>
-      <div><dt>Sorties</dt><dd id="ro-sorties">0</dd></div>
-      <div><dt>Kills</dt><dd id="ro-kills">0</dd></div>
-    </dl>
+    <nav class="nav" aria-label="Sections">
+      <a href="/" data-nav="dashboard">Debrief</a>
+      <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/weapons" data-nav="weapons">Weapons</a>
+      <a href="/log" data-nav="log">Log</a>
+    </nav>
 
     <div class="controls">
-      <a class="link-a" href="/">← Debrief</a>
       <button id="share" type="button">Copy link</button>
       <label class="vh" for="q">Filter everything</label>
       <input type="search" id="q" placeholder="Search pilots, aircraft, weapons…" autocomplete="off">

--- a/web/missions.html
+++ b/web/missions.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- Declared before any CSS arrives so the browser paints the canvas in a
+     sane colour from the first frame. app.js narrows it to the chosen theme. -->
+<meta name="color-scheme" content="light dark">
+<title>Missions — Overlord</title>
+<link rel="stylesheet" href="/app.css">
+<script>
+  // Resolve the theme before first paint. app.css has no prefers-color-scheme
+  // block: it styles data-theme only, so this attribute has to exist by the
+  // time the stylesheet applies or the page flashes the wrong theme.
+  (function () {
+    var saved = null;
+    try { saved = localStorage.getItem("overlord-theme"); } catch (e) { /* private mode */ }
+    var dark = saved ? saved === "dark" : matchMedia("(prefers-color-scheme: dark)").matches;
+    document.documentElement.setAttribute("data-theme", dark ? "dark" : "light");
+  })();
+</script>
+</head>
+<body data-page="missions">
+
+<!-- The same header on every section. The four-figure readout that used to sit
+     here is gone: mission time was already in the hero below it, and the other
+     three were a summary of a page that now has sections of its own. Navigation
+     is worth more than a duplicate. -->
+<header class="top">
+  <div class="top-in">
+    <a class="brand" href="/">
+      <b>Overlord</b>
+      <span>DCS debrief</span>
+    </a>
+
+    <nav class="nav" aria-label="Sections">
+      <a href="/" data-nav="dashboard">Debrief</a>
+      <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/weapons" data-nav="weapons">Weapons</a>
+      <a href="/log" data-nav="log">Log</a>
+    </nav>
+
+    <div class="controls">
+      <label class="vh" for="q">Filter everything</label>
+      <input type="search" id="q" placeholder="Filter missions…" autocomplete="off">
+      <button id="theme" type="button">Theme</button>
+      <label class="toggle"><input type="checkbox" id="live" checked> Live</label>
+      <span id="link" class="status" role="status">Connecting</span>
+    </div>
+  </div>
+</header>
+
+<main>
+
+  <section class="card-panel" id="p-missions">
+    <div class="phead"><h2>Missions</h2></div>
+    <p class="note">
+      Every recorded run, newest first. Each has a page of its own — the scoreboard, the map with its
+      replay, and everything that happened — worth pasting into chat. Runs under fifty events are left
+      out; those are server restarts rather than a night worth reading back.
+    </p>
+    <ol id="missions" class="missions"></ol>
+  </section>
+
+</main>
+</main>
+
+<!-- Reference card. Opened by clicking any aircraft or weapon name.
+     A native <dialog> opened with showModal(): the focus trap, Escape to
+     close, the inert background and the backdrop all come with it. The
+     hand-rolled version of this left every control behind it tabbable. -->
+<dialog id="card" class="card" closedby="any" aria-labelledby="card-name">
+  <div class="card-head">
+    <div>
+      <h3 id="card-name">—</h3>
+      <p id="card-sub" class="card-sub"></p>
+    </div>
+    <button id="card-close" type="button">Close</button>
+  </div>
+  <div id="card-body"></div>
+</dialog>
+
+<footer id="foot"></footer>
+
+<script src="/app.js"></script>
+</body>
+</html>

--- a/web/player.html
+++ b/web/player.html
@@ -30,17 +30,23 @@
 
 <header class="top">
   <div class="top-in">
-    <div class="brand">
-      <a href="/"><b>Overlord</b></a>
+    <a class="brand" href="/">
+      <b>Overlord</b>
       <span>Pilot record</span>
-    </div>
+    </a>
+
+    <nav class="nav" aria-label="Sections">
+      <a href="/" data-nav="dashboard">Debrief</a>
+      <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/weapons" data-nav="weapons">Weapons</a>
+      <a href="/log" data-nav="log">Log</a>
+    </nav>
 
     <div class="controls">
       <div class="chips" id="scope" role="group" aria-label="Time range">
         <button type="button" data-scope="mission" class="on">This mission</button>
         <button type="button" data-scope="all">All time</button>
       </div>
-      <a class="link-a" href="/">← Debrief</a>
       <label class="vh" for="q">Filter this pilot's tables</label>
       <input type="search" id="q" placeholder="Filter aircraft, weapons…" autocomplete="off">
       <button id="theme" type="button">Theme</button>

--- a/web/weapons.html
+++ b/web/weapons.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- Declared before any CSS arrives so the browser paints the canvas in a
+     sane colour from the first frame. app.js narrows it to the chosen theme. -->
+<meta name="color-scheme" content="light dark">
+<title>Weapons — Overlord</title>
+<link rel="stylesheet" href="/app.css">
+<script>
+  // Resolve the theme before first paint. app.css has no prefers-color-scheme
+  // block: it styles data-theme only, so this attribute has to exist by the
+  // time the stylesheet applies or the page flashes the wrong theme.
+  (function () {
+    var saved = null;
+    try { saved = localStorage.getItem("overlord-theme"); } catch (e) { /* private mode */ }
+    var dark = saved ? saved === "dark" : matchMedia("(prefers-color-scheme: dark)").matches;
+    document.documentElement.setAttribute("data-theme", dark ? "dark" : "light");
+  })();
+</script>
+</head>
+<body data-page="weapons">
+
+<!-- The same header on every section. The four-figure readout that used to sit
+     here is gone: mission time was already in the hero below it, and the other
+     three were a summary of a page that now has sections of its own. Navigation
+     is worth more than a duplicate. -->
+<header class="top">
+  <div class="top-in">
+    <a class="brand" href="/">
+      <b>Overlord</b>
+      <span>DCS debrief</span>
+    </a>
+
+    <nav class="nav" aria-label="Sections">
+      <a href="/" data-nav="dashboard">Debrief</a>
+      <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/weapons" data-nav="weapons">Weapons</a>
+      <a href="/log" data-nav="log">Log</a>
+    </nav>
+
+    <div class="controls">
+      <div class="chips" id="scope" role="group" aria-label="Time range">
+        <button type="button" data-scope="mission" class="on">This mission</button>
+        <button type="button" data-scope="all">All time</button>
+      </div>
+      <label class="vh" for="q">Filter everything</label>
+      <input type="search" id="q" placeholder="Filter weapons…" autocomplete="off">
+      <button id="theme" type="button">Theme</button>
+      <label class="toggle"><input type="checkbox" id="live" checked> Live</label>
+      <span id="link" class="status" role="status">Connecting</span>
+    </div>
+  </div>
+</header>
+
+<main>
+
+  <section class="card-panel" id="p-weapons">
+    <div class="phead">
+      <h2>Weapons</h2>
+      <div class="chips" id="weapon-class" role="group" aria-label="Filter by weapon type">
+        <button type="button" data-class="all" class="on">All</button>
+        <button type="button" data-class="ordnance">Missiles &amp; bombs</button>
+        <button type="button" data-class="gun">Guns</button>
+        <button type="button" data-class="collision">Collisions</button>
+      </div>
+    </div>
+    <p class="note">
+      Hits per shot is a ratio and can exceed 1 legitimately — DCS reports one shot per launch but one hit per
+      object damaged, so cluster and splash weapons register several. Guns report hits and no shots, so they
+      have no ratio. Rows named after an aircraft are collisions, where DCS names the aircraft as the weapon;
+      those are counted apart from hits and kills so they do not flatter any weapon's figures.
+    </p>
+    <div class="tw"><table id="weapons" class="grid"></table></div>
+  </section>
+
+  <section class="card-panel" id="p-collateral">
+    <div class="phead"><h2>Collateral damage</h2></div>
+    <p class="note">What the ordnance above caught that was never a threat.</p>
+    <div id="collateral"></div>
+  </section>
+
+</main>
+</main>
+
+<!-- Reference card. Opened by clicking any aircraft or weapon name.
+     A native <dialog> opened with showModal(): the focus trap, Escape to
+     close, the inert background and the backdrop all come with it. The
+     hand-rolled version of this left every control behind it tabbable. -->
+<dialog id="card" class="card" closedby="any" aria-labelledby="card-name">
+  <div class="card-head">
+    <div>
+      <h3 id="card-name">—</h3>
+      <p id="card-sub" class="card-sub"></p>
+    </div>
+    <button id="card-close" type="button">Close</button>
+  </div>
+  <div id="card-body"></div>
+</dialog>
+
+<footer id="foot"></footer>
+
+<script src="/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
The landing page had grown to nine panels at identical visual weight. The diagnosis is that they answer **four different questions**, on four different rhythms:

| Question | Panels | When you ask it |
|---|---|---|
| What just happened? | hero, records, map, leaderboard, landings, tasks | right after a flight |
| What happened before? | missions — **43 rows** | browsing |
| How does the kit perform? | weapons — **139 rows**, collateral | when curious |
| Show me everything | event log — **200 rows** | when something looks wrong |

The 43-row mission list and the 200-row log sat *between* the scoreboard and the leaderboard.

## Four pages, one job each

```
/          Debrief   hero · records · map · leaderboard + landings · tasks
/missions  Missions  the index of runs
/weapons   Weapons   effectiveness · collateral damage
/log       Log       the event firehose and its filters
```

Debrief goes from **9 panels to 6**.

## Navigation, and one less duplicate

The header gains a nav and loses the four-figure readout. Mission time was already in the hero *directly below it*; the other three summarised a page that now has sections of its own. And until now there was **no navigation at all** — once pilot and mission pages existed you could only ever go back.

Nav is styled as links rather than chips, deliberately: these go to pages, and making them look like the filter chips would say they toggle something. A mission recap lights **Missions**, since it is one.

**The recap keeps all nine panels on purpose.** It is the complete record of one run, opened deliberately to read all of it. The debrief is what is happening *now*. Different jobs, different density.

## Each page fetches only what it draws

The query is composed from the panels the page actually has, asked of the DOM rather than a second list to keep in step with the markup:

| Page | GraphQL fields requested | Leaflet |
|---|---|---|
| `/missions` | `missions` | not loaded |
| `/log` | `missions`, `units`, `weapons` | not loaded |
| `/weapons` | `missions`, `weaponEffectiveness`, `collateral`, `units`, `weapons` | not loaded |
| `/` | everything the debrief renders — no weapons table, no log | loaded |

Every page previously fetched the weapons table, the whole event log, the map and the records.

## One fix that fell out

The hero clock read the newest row in the event log, which only one section fetches now. It reads the mission's own `duration` instead — the same number by a shorter route, and it can no longer show a dead run's `01:12:55` while the live mission is ten minutes old.

## Verified in the browser

All six routes return 200. Debrief renders 6 panels with nav on **Debrief**; `/missions` lists 43 runs, filters to 0 on a bogus search and back to 43, no scope chips, no Leaflet; `/weapons` shows 139 rows all-time and 35 under the collision filter with its extra column; `/log` renders 200 rows and its filters work; `/mission/37` keeps all 9 panels, 53 map dots, share button, nav on **Missions**; `/player/4` keeps its 29 badges. Mobile at 375px: all four nav links on one row, no horizontal scroll. No console errors on any page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)