### PR TITLE
Make the mission index worth reading

### DIFF
--- a/controllers/missionIndex.go
+++ b/controllers/missionIndex.go
@@ -1,0 +1,260 @@
+package controllers
+
+import (
+	"sort"
+
+	"github.com/MartinHell/overlord/initializers"
+	"github.com/MartinHell/overlord/logs"
+	"github.com/MartinHell/overlord/models"
+)
+
+// The mission index: every recorded run with enough about it to choose one.
+//
+// A list of forty-three rows reading "Kolkhi_Test · Caucasus" tells you nothing
+// about which night to open. Kills, who flew, and one standout moment do.
+//
+// Four queries and a pass over the kills in Go, rather than per-mission
+// queries: forty-three missions would otherwise mean a hundred and thirty
+// round trips to say the same thing.
+
+// multiKillWindow is how close kills have to be to count as a burst. Matches
+// the Hat Trick badge, so the page and the shelf agree about what a burst is.
+const multiKillWindow = 60.0
+
+// longShotNm is the range past which a shot is worth remarking on. Well short
+// of the Long Shot badge's fifteen, because this is the best of one mission
+// rather than a career achievement.
+const longShotNm = 8.0
+
+// killFact is one kill, reduced to what a highlight needs.
+type killFact struct {
+	MissionID    uint
+	PlayerID     uint
+	PlayerName   string
+	MissionTime  float64
+	InitiatorLat float64
+	InitiatorLon float64
+	TargetLat    float64
+	TargetLon    float64
+}
+
+// GetMissionIndex lists every recorded mission, newest first, with the extra
+// detail the index page shows.
+func GetMissionIndex() ([]*models.MissionEntry, error) {
+	base, err := GetMissions()
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]*models.MissionEntry, 0, len(base))
+	byID := map[uint]*models.MissionEntry{}
+	for _, m := range base {
+		e := &models.MissionEntry{MissionSummary: *m}
+		entries = append(entries, e)
+		byID[m.MissionID] = e
+	}
+	if len(entries) == 0 {
+		return entries, nil
+	}
+
+	// Kills and sorties per mission.
+	var totals []struct {
+		MissionID uint
+		Kills     int
+		Sorties   int
+	}
+	if err := initializers.DB.Model(&models.Event{}).
+		Select(`events.mission_id AS mission_id,
+			SUM(CASE WHEN events.event = 'kill' AND `+notScenery+` THEN 1 ELSE 0 END) AS kills,
+			SUM(CASE WHEN events.event IN ('takeoff','runway_takeoff') THEN 1 ELSE 0 END) AS sorties`).
+		Joins("LEFT JOIN targets ON targets.target_id = events.target_id").
+		Where("events.mission_id IS NOT NULL").
+		Group("events.mission_id").
+		Scan(&totals).Error; err != nil {
+		logs.Sugar.Errorf("Failed to total missions: %v", err)
+		return nil, err
+	}
+	for _, t := range totals {
+		if e := byID[t.MissionID]; e != nil {
+			e.Kills = t.Kills
+			e.Sorties = t.Sorties
+		}
+	}
+
+	// Which humans flew each mission, and what they got. AI is left out: it is
+	// in every mission, so listing it distinguishes none of them.
+	var pilots []struct {
+		MissionID  uint
+		PlayerID   uint
+		PlayerName string
+		Kills      int
+	}
+	if err := initializers.DB.Model(&models.Event{}).
+		Select(`events.mission_id AS mission_id,
+			players.player_id AS player_id,
+			players.player_name AS player_name,
+			SUM(CASE WHEN events.event = 'kill' AND `+notScenery+` THEN 1 ELSE 0 END) AS kills`).
+		Joins("JOIN players ON players.player_id = events.player_id").
+		Joins("LEFT JOIN targets ON targets.target_id = events.target_id").
+		Where("events.mission_id IS NOT NULL AND players.player_name NOT LIKE ?", "AI-Unit%").
+		Group("events.mission_id, players.player_id, players.player_name").
+		Scan(&pilots).Error; err != nil {
+		logs.Sugar.Errorf("Failed to list mission pilots: %v", err)
+		return nil, err
+	}
+	for _, p := range pilots {
+		if e := byID[p.MissionID]; e != nil {
+			e.Pilots = append(e.Pilots, &models.MissionPilot{
+				PlayerID: p.PlayerID, PlayerName: p.PlayerName, Kills: p.Kills,
+			})
+		}
+	}
+	for _, e := range entries {
+		sort.SliceStable(e.Pilots, func(i, j int) bool {
+			if e.Pilots[i].Kills != e.Pilots[j].Kills {
+				return e.Pilots[i].Kills > e.Pilots[j].Kills
+			}
+			return e.Pilots[i].PlayerName < e.Pilots[j].PlayerName
+		})
+	}
+
+	// Every kill, once, for the highlights. One scan beats a query per mission,
+	// and the row is small enough that the whole history fits comfortably.
+	var kills []killFact
+	if err := initializers.DB.Model(&models.Event{}).
+		Select(`events.mission_id AS mission_id,
+			events.player_id AS player_id,
+			players.player_name AS player_name,
+			events.mission_time AS mission_time,
+			events.initiator_lat AS initiator_lat,
+			events.initiator_lon AS initiator_lon,
+			events.target_lat AS target_lat,
+			events.target_lon AS target_lon`).
+		Joins("JOIN players ON players.player_id = events.player_id").
+		Joins("LEFT JOIN targets ON targets.target_id = events.target_id").
+		Where("events.event = ? AND events.mission_id IS NOT NULL AND "+notScenery, "kill").
+		Order("events.mission_id, events.id").
+		Scan(&kills).Error; err != nil {
+		logs.Sugar.Errorf("Failed to load kills for mission highlights: %v", err)
+		return nil, err
+	}
+
+	perMission := map[uint][]killFact{}
+	for _, k := range kills {
+		perMission[k.MissionID] = append(perMission[k.MissionID], k)
+	}
+	for id, ks := range perMission {
+		if e := byID[id]; e != nil {
+			e.Highlight = highlightOf(ks)
+		}
+	}
+
+	return entries, nil
+}
+
+// highlightOf picks the one thing worth saying about a mission.
+//
+// Humans win ties they have no business winning: a night where a real pilot
+// took two aircraft is a better story than one where an AI coalition took
+// ninety, because the AI does that every night. Only when no human did
+// anything at all does the AI's tally get the line.
+func highlightOf(kills []killFact) *models.MissionHighlight {
+	if len(kills) == 0 {
+		return nil
+	}
+
+	human := make([]killFact, 0, len(kills))
+	for _, k := range kills {
+		if !models.IsAIPlayerName(k.PlayerName) {
+			human = append(human, k)
+		}
+	}
+
+	if h := bestHighlight(human, true); h != nil {
+		return h
+	}
+	return bestHighlight(kills, false)
+}
+
+// bestHighlight finds the most interesting thing in one set of kills, by the
+// order the Highlight kinds are declared in.
+//
+// asPilot says whether these kills belong to one person. Only then do bursts
+// and totals mean anything: the synthetic AI players pool a whole coalition, so
+// "twelve kills in twenty-four seconds" is the entire blue air force having a
+// busy minute rather than somebody's moment. Allowing it made thirty-seven of
+// forty-three missions read the same way, which is the opposite of telling them
+// apart. A long shot survives, because a single missile flying fifteen miles is
+// one event no matter who is credited with it.
+func bestHighlight(kills []killFact, asPilot bool) *models.MissionHighlight {
+	if len(kills) == 0 {
+		return nil
+	}
+
+	byPlayer := map[uint][]killFact{}
+	for _, k := range kills {
+		byPlayer[k.PlayerID] = append(byPlayer[k.PlayerID], k)
+	}
+
+	var burst, ace, shot, top *models.MissionHighlight
+
+	for id, ks := range byPlayer {
+		pid := id
+		name := ks[0].PlayerName
+
+		if asPilot {
+			// A burst: the most kills any window of sixty seconds holds.
+			timed := make([]float64, 0, len(ks))
+			for _, k := range ks {
+				if k.MissionTime > 0 {
+					timed = append(timed, k.MissionTime)
+				}
+			}
+			sort.Float64s(timed)
+			for i := 0; i < len(timed); i++ {
+				j := i
+				for j+1 < len(timed) && timed[j+1]-timed[i] <= multiKillWindow {
+					j++
+				}
+				n := j - i + 1
+				if n >= 3 && (burst == nil || n > burst.Count) {
+					burst = &models.MissionHighlight{
+						Kind: models.HighlightMultiKill, PlayerID: &pid, PlayerName: name,
+						Count: n, Seconds: timed[j] - timed[i],
+					}
+				}
+			}
+
+			if len(ks) >= 5 && (ace == nil || len(ks) > ace.Count) {
+				ace = &models.MissionHighlight{
+					Kind: models.HighlightAce, PlayerID: &pid, PlayerName: name, Count: len(ks),
+				}
+			}
+		}
+
+		for _, k := range ks {
+			if k.InitiatorLat == 0 || k.TargetLat == 0 {
+				continue
+			}
+			nm := haversineM(k.InitiatorLat, k.InitiatorLon, k.TargetLat, k.TargetLon) / 1852
+			if nm >= longShotNm && (shot == nil || nm > shot.Nm) {
+				shot = &models.MissionHighlight{
+					Kind: models.HighlightLongShot, PlayerID: &pid, PlayerName: name, Nm: nm,
+				}
+			}
+		}
+
+		if asPilot && len(ks) >= 2 && (top == nil || len(ks) > top.Count) {
+			top = &models.MissionHighlight{
+				Kind: models.HighlightTopScorer, PlayerID: &pid, PlayerName: name, Count: len(ks),
+			}
+		}
+	}
+
+	for _, h := range []*models.MissionHighlight{burst, ace, shot, top} {
+		if h != nil {
+			return h
+		}
+	}
+	return nil
+}

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -67,6 +67,15 @@ models:
   Sortie:
     model:
       - github.com/MartinHell/overlord/models.Sortie
+  MissionEntry:
+    model:
+      - github.com/MartinHell/overlord/models.MissionEntry
+  MissionPilot:
+    model:
+      - github.com/MartinHell/overlord/models.MissionPilot
+  MissionHighlight:
+    model:
+      - github.com/MartinHell/overlord/models.MissionHighlight
   Rivalry:
     model:
       - github.com/MartinHell/overlord/models.Rivalry

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -44,6 +44,25 @@ func (r *missionResolver) ID(ctx context.Context, obj *models.MissionSummary) (s
 	return fmt.Sprintf("%v", obj.MissionID), nil
 }
 
+// ID is the resolver for the id field.
+func (r *missionEntryResolver) ID(ctx context.Context, obj *models.MissionEntry) (string, error) {
+	return fmt.Sprintf("%v", obj.MissionID), nil
+}
+
+// PlayerID is the resolver for the playerID field.
+func (r *missionHighlightResolver) PlayerID(ctx context.Context, obj *models.MissionHighlight) (*string, error) {
+	if obj.PlayerID == nil {
+		return nil, nil
+	}
+	id := fmt.Sprintf("%v", *obj.PlayerID)
+	return &id, nil
+}
+
+// PlayerID is the resolver for the playerID field.
+func (r *missionPilotResolver) PlayerID(ctx context.Context, obj *models.MissionPilot) (string, error) {
+	return fmt.Sprintf("%v", obj.PlayerID), nil
+}
+
 // PlayerID is the resolver for the playerID field.
 func (r *missionTaskResolver) PlayerID(ctx context.Context, obj *models.MissionTask) (*string, error) {
 	if obj.PlayerID == nil {
@@ -130,6 +149,11 @@ func (r *queryResolver) Events(ctx context.Context, first *int, after *string, e
 // Missions is the resolver for the missions field.
 func (r *queryResolver) Missions(ctx context.Context) ([]*models.MissionSummary, error) {
 	return controllers.GetMissions()
+}
+
+// MissionIndex is the resolver for the missionIndex field.
+func (r *queryResolver) MissionIndex(ctx context.Context) ([]*models.MissionEntry, error) {
+	return controllers.GetMissionIndex()
 }
 
 // KillsByCoalition returns the kill tally for every coalition at once.
@@ -372,6 +396,17 @@ func (r *Resolver) KillRecord() generated.KillRecordResolver { return &killRecor
 // Mission returns generated.MissionResolver implementation.
 func (r *Resolver) Mission() generated.MissionResolver { return &missionResolver{r} }
 
+// MissionEntry returns generated.MissionEntryResolver implementation.
+func (r *Resolver) MissionEntry() generated.MissionEntryResolver { return &missionEntryResolver{r} }
+
+// MissionHighlight returns generated.MissionHighlightResolver implementation.
+func (r *Resolver) MissionHighlight() generated.MissionHighlightResolver {
+	return &missionHighlightResolver{r}
+}
+
+// MissionPilot returns generated.MissionPilotResolver implementation.
+func (r *Resolver) MissionPilot() generated.MissionPilotResolver { return &missionPilotResolver{r} }
+
 // MissionTask returns generated.MissionTaskResolver implementation.
 func (r *Resolver) MissionTask() generated.MissionTaskResolver { return &missionTaskResolver{r} }
 
@@ -423,6 +458,9 @@ type (
 	favouriteResolver           struct{ *Resolver }
 	killRecordResolver          struct{ *Resolver }
 	missionResolver             struct{ *Resolver }
+	missionEntryResolver        struct{ *Resolver }
+	missionHighlightResolver    struct{ *Resolver }
+	missionPilotResolver        struct{ *Resolver }
 	missionTaskResolver         struct{ *Resolver }
 	playerResolver              struct{ *Resolver }
 	playerActivityResolver      struct{ *Resolver }

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -377,6 +377,61 @@ type Mission {
 }
 
 """
+One row of the mission index: the summary plus what makes this run worth
+opening rather than the one above it.
+
+Separate from Mission because the extra detail costs three more queries and a
+pass over every kill, and Mission is fetched on every page load.
+"""
+type MissionEntry {
+    id: ID!
+    name: String!
+    theatre: String!
+    startedAt: Time!
+    events: Int!
+    duration: Float!
+
+    "Excludes scenery, like every other kill figure."
+    kills: Int!
+    "Takeoffs by anyone, AI included: a measure of how busy the sky was."
+    sorties: Int!
+    """
+    The humans who flew it, busiest first. AI is deliberately absent — it is in
+    every mission, so it distinguishes none of them.
+    """
+    pilots: [MissionPilot!]!
+    "The one thing worth saying about this run. Null when nothing stood out."
+    highlight: MissionHighlight
+}
+
+"One human's presence in a mission."
+type MissionPilot {
+    playerID: ID!
+    playerName: String!
+    kills: Int!
+}
+
+"""
+The standout moment of one run. The client phrases it from these parts.
+
+A human's moment wins over an AI's, even a smaller one: a night where a real
+pilot took two aircraft is a better story than one where an AI coalition took
+ninety, because the AI does that every night.
+"""
+type MissionHighlight {
+    "One of: multikill, ace, longshot, topscorer."
+    kind: String!
+    playerID: ID
+    playerName: String!
+    "Kills — in the burst, in the mission, or the scorer's total."
+    count: Int!
+    "How long a multikill took. Zero for other kinds."
+    seconds: Float!
+    "The range of a long shot, in nautical miles. Zero for other kinds."
+    nm: Float!
+}
+
+"""
 The standout moments of a mission.
 
 Everything else here is an aggregate, which says how a mission went but never
@@ -593,6 +648,8 @@ type Query {
     events(first: Int, after: String, eventType: String, coalition: String, missionID: ID): EventConnection
     "Recorded missions, newest first."
     missions: [Mission!]!
+    "Every recorded run with the detail the index page shows. Heavier than missions; ask for it only there."
+    missionIndex: [MissionEntry!]!
     "Kill tally per coalition, covering both sides. Omit missionID for all of recorded history."
     killsByCoalition(missionID: ID): [CoalitionKills!]!
     "Shots, hits, kills, accuracy and Pk per weapon type."

--- a/models/missionModel.go
+++ b/models/missionModel.go
@@ -36,3 +36,56 @@ type MissionSummary struct {
 	// Duration is the highest mission clock seen, in seconds.
 	Duration float64
 }
+
+// MissionEntry is one row of the mission index: the summary plus what makes
+// this run worth opening rather than the one above it.
+//
+// Kept apart from MissionSummary because the extra work is real -- three more
+// queries and a pass over every kill -- and the summary is fetched on every
+// page load by the badge shelf, the flight log and the hero. Only the index
+// asks for this.
+type MissionEntry struct {
+	MissionSummary
+	// Kills excludes scenery, like every other kill figure.
+	Kills int
+	// Sorties is takeoffs by anyone, AI included: it is a measure of how busy
+	// the sky was.
+	Sorties int
+	// Pilots are the humans who flew it, busiest first. AI is deliberately
+	// absent -- it is in every mission, so it distinguishes none of them.
+	Pilots []*MissionPilot
+	// Highlight is the one thing worth saying about this run. Nil when nothing
+	// stood out, which is honest: some nights are quiet.
+	Highlight *MissionHighlight
+}
+
+// MissionPilot is one human's presence in a mission.
+type MissionPilot struct {
+	PlayerID   uint
+	PlayerName string
+	Kills      int
+}
+
+// Highlight kinds, in the order they are preferred. A burst of kills is a
+// better story than a total, and a total is better than nothing.
+const (
+	HighlightMultiKill = "multikill"
+	HighlightAce       = "ace"
+	HighlightLongShot  = "longshot"
+	HighlightTopScorer = "topscorer"
+)
+
+// MissionHighlight is the standout moment of one run, phrased by the client
+// from these parts rather than here -- wording lives with the rest of the
+// wording.
+type MissionHighlight struct {
+	Kind       string
+	PlayerID   *uint
+	PlayerName string
+	// Count is kills: in the burst, in the mission, or the scorer's total.
+	Count int
+	// Seconds is how long a multikill took; Nm the range of a long shot.
+	// Each is zero when the kind does not use it.
+	Seconds float64
+	Nm      float64
+}

--- a/web/app.css
+++ b/web/app.css
@@ -1304,3 +1304,70 @@ a.brand:hover b { text-decoration: underline; }
 
 /* The controls no longer need to claim the free space; the nav does. */
 .controls { margin-left: 0; }
+
+/* ---- mission index ---- */
+/* Rewritten as cards. A row of name-and-date told you which runs existed but
+   nothing about which to open; the numbers and the standout moment do. */
+.missions { margin: 0; padding: 0; list-style: none; display: grid; gap: 0.6rem; }
+
+.mission-card {
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+}
+.mission-card.is-live { border-color: var(--ok); }
+
+.mc-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.35rem 0.6rem; }
+.mc-name { font-size: 0.9375rem; font-weight: 600; color: inherit; text-decoration: none; }
+.mc-name:hover { text-decoration: underline; }
+.mc-when { color: var(--text-dim); font-size: 0.8125rem; }
+
+/* Four figures on one line, tabular so a column of cards reads down as well
+   as across. */
+.mc-stats { display: flex; flex-wrap: wrap; gap: 0.2rem 1.6rem; margin: 0.6rem 0 0; }
+.mc-stats div { display: flex; flex-direction: column; gap: 0.05rem; }
+.mc-stats dt {
+  color: var(--text-faint);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.mc-stats dd { margin: 0; font-size: 0.9375rem; font-weight: 600; font-variant-numeric: tabular-nums; }
+
+/* The one line that sets this run apart from the one above it, so it gets the
+   only colour on the card. */
+.mc-highlight {
+  margin: 0.6rem 0 0;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--line);
+  color: var(--text-dim);
+  font-size: 0.8125rem;
+}
+.mc-highlight span { color: var(--gold); }
+.mc-highlight b { color: var(--text); font-weight: 600; }
+
+.mc-pilots { margin: 0.3rem 0 0; color: var(--text-faint); font-size: 0.75rem; }
+
+.count { color: var(--text-faint); font-size: 0.8125rem; font-variant-numeric: tabular-nums; }
+
+/* The pilot picker: a real select, because the list grows with the roster and
+   chips would not. */
+.pick {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text-dim);
+  font-size: 0.8125rem;
+  white-space: nowrap;
+}
+.pick select {
+  padding: 0.35rem 0.5rem;
+  background: var(--surface-2);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.8125rem;
+}

--- a/web/app.js
+++ b/web/app.js
@@ -71,6 +71,15 @@ const state = {
   // are the whole point of the page being live.
   scope: "mission",
   missionID: null,
+  // Which pilot the mission index is narrowed to, remembered across visits so
+  // "the ones I was in" only has to be answered once. Empty means anyone.
+  pilotFilter: (() => {
+    try {
+      return localStorage.getItem("overlord-pilot") || "";
+    } catch {
+      return ""; // private mode
+    }
+  })(),
   sort: {
     weapons: { key: "shots", dir: -1 },
     pilots: { key: "takeoffs", dir: -1 },
@@ -130,6 +139,15 @@ function dashQuery() {
 
   return `{
   missions { id name theatre startedAt events duration }
+  ${
+    wants("missions")
+      ? `missionIndex {
+    id name theatre startedAt events duration kills sorties
+    pilots { playerID playerName kills }
+    highlight { kind playerID playerName count seconds nm }
+  }`
+      : ""
+  }
   ${wants("tug-blue") ? `killsByCoalition${p} { coalition kills teamkills }` : ""}
   ${wants("weapons") ? `weaponEffectiveness${p} { weaponType shots hits kills collisions hitsPerShot killsPerShot }` : ""}
   ${wants("pilots") ? `playerActivity${p} { playerID playerName kills takeoffs landings crashes ejections deaths }` : ""}
@@ -676,36 +694,107 @@ function drawLog(connection) {
 
 // --- draw / refresh --------------------------------------------------------
 
+// The one thing worth saying about a run, phrased here from the parts the
+// server sends. Wording lives with the rest of the wording.
+function highlightLine(h) {
+  if (!h) return "";
+  const who = pref(h.playerID, h.playerName);
+  switch (h.kind) {
+    case "multikill":
+      return `${who} took <b>${h.count}</b> inside ${Math.round(h.seconds)} seconds`;
+    case "ace":
+      return `${who} went <b>${h.count}</b> for the night`;
+    case "longshot":
+      return `a <b>${h.nm.toFixed(1)} nm</b> shot by ${who}`;
+    case "topscorer":
+      return `${who} led with <b>${h.count}</b>`;
+    default:
+      return "";
+  }
+}
+
 // The index of recorded runs. Newest first, each linking to its own recap.
+//
 // Quiet runs are dropped: a mission that recorded four events is a server
 // restart, not a night worth reading back.
 function drawMissions(missions) {
   const host = el("missions");
   if (!host) return;
 
+  fillPilotFilter(missions);
+
   const rows = missions
     .filter((m) => m.events >= 50)
-    .filter((m) => matches([m.name, m.theatre]));
+    .filter((m) => matches([m.name, m.theatre, ...(m.pilots || []).map((p) => p.playerName)]))
+    .filter((m) => !state.pilotFilter || (m.pilots || []).some((p) => p.playerID === state.pilotFilter));
+
+  el("mission-count").textContent = rows.length
+    ? `${rows.length} of ${missions.filter((m) => m.events >= 50).length} runs`
+    : "";
 
   if (!rows.length) {
-    host.innerHTML = `<li class="none">No missions recorded yet.</li>`;
+    host.innerHTML = `<li class="none">${
+      state.pilotFilter ? "No missions recorded for that pilot yet." : "No missions recorded yet."
+    }</li>`;
     return;
   }
 
   host.innerHTML = rows
     .map((m) => {
       const when = m.startedAt ? new Date(m.startedAt) : null;
-      const stamp = when && !isNaN(when) ? when.toLocaleDateString(undefined, { day: "numeric", month: "short" }) : "";
-      const live = m.id === state.missionID && !state.pinnedMission;
-      return `<li class="mission-row">
-        <a class="mission-link" href="/mission/${encodeURIComponent(m.id)}">
-          <span class="mission-name">${esc(m.name || `Mission ${m.id}`)}</span>
-          <span class="mission-meta">${esc(m.theatre || "")}${stamp ? " · " + esc(stamp) : ""} · ${dur(m.duration)}</span>
-        </a>
-        <span class="mission-events">${num(m.events)} events${live ? ` <b class="mission-live">live</b>` : ""}</span>
+      const stamp =
+        when && !isNaN(when)
+          ? when.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" })
+          : "";
+      const live = m.id === state.missionID;
+      const line = highlightLine(m.highlight);
+      const flew = (m.pilots || []).map((p) => pref(p.playerID, p.playerName)).join(", ");
+
+      return `<li class="mission-card${live ? " is-live" : ""}">
+        <div class="mc-head">
+          <a class="mc-name" href="/mission/${encodeURIComponent(m.id)}">${esc(m.name || `Mission ${m.id}`)}</a>
+          ${live ? `<b class="mission-live">live</b>` : ""}
+          <span class="mc-when">${esc(m.theatre || "Unknown map")}${stamp ? " · " + esc(stamp) : ""}</span>
+        </div>
+
+        <dl class="mc-stats">
+          <div><dt>Kills</dt><dd>${num(m.kills)}</dd></div>
+          <div><dt>Sorties</dt><dd>${num(m.sorties)}</dd></div>
+          <div><dt>Ran for</dt><dd>${dur(m.duration)}</dd></div>
+          <div><dt>Events</dt><dd>${num(m.events)}</dd></div>
+        </dl>
+
+        ${line ? `<p class="mc-highlight"><span aria-hidden="true">★</span> ${line}</p>` : ""}
+        ${flew ? `<p class="mc-pilots">Flown by ${flew}</p>` : ""}
       </li>`;
     })
     .join("");
+}
+
+// The pilot picker, filled from the runs themselves: whoever has flown is
+// whoever you can filter by. There is no login, so "missions I was in" has to
+// be asked as a question -- and the answer is remembered, so it only has to be
+// answered once.
+function fillPilotFilter(missions) {
+  const sel = el("pilot-filter");
+  if (!sel || sel.dataset.filled) return;
+
+  const seen = new Map();
+  for (const m of missions) {
+    for (const p of m.pilots || []) if (!seen.has(p.playerID)) seen.set(p.playerID, p.playerName);
+  }
+  if (!seen.size) return;
+
+  sel.dataset.filled = "1";
+  sel.innerHTML =
+    `<option value="">Anyone</option>` +
+    [...seen.entries()]
+      .sort((a, b) => a[1].localeCompare(b[1]))
+      .map(([id, name]) => `<option value="${esc(id)}">${esc(playerLabel(name))}</option>`)
+      .join("");
+
+  if (state.pilotFilter && seen.has(state.pilotFilter)) sel.value = state.pilotFilter;
+  else state.pilotFilter = "";
 }
 
 // Every section runs the same draw. Each panel is skipped when the page it
@@ -719,7 +808,7 @@ function draw() {
   for (const w of d.weapons || []) names.weapon.set(w.type, w.displayName);
 
   if (wants("hero-title")) drawHero(d);
-  if (wants("missions")) drawMissions(d.missions || []);
+  if (wants("missions")) drawMissions(d.missionIndex || []);
   if (wants("weapons")) drawWeapons(d.weaponEffectiveness || []);
   if (wants("pilots")) drawPilots(d.playerActivity || []);
   if (wants("traps")) drawTraps(d.landingGrades || []);
@@ -2135,6 +2224,16 @@ if (PAGE === "player") {
 if (PAGE === "missions") {
   el("q").addEventListener("input", (e) => {
     state.query = e.target.value.trim().toLowerCase();
+    draw();
+  });
+
+  el("pilot-filter").addEventListener("change", (e) => {
+    state.pilotFilter = e.target.value;
+    try {
+      localStorage.setItem("overlord-pilot", state.pilotFilter);
+    } catch {
+      /* private mode: the filter still works, it just will not be remembered */
+    }
     draw();
   });
 }

--- a/web/missions.html
+++ b/web/missions.html
@@ -41,6 +41,9 @@
     </nav>
 
     <div class="controls">
+      <label class="pick">Flown by
+        <select id="pilot-filter"><option value="">Anyone</option></select>
+      </label>
       <label class="vh" for="q">Filter everything</label>
       <input type="search" id="q" placeholder="Filter missions…" autocomplete="off">
       <button id="theme" type="button">Theme</button>
@@ -53,7 +56,10 @@
 <main>
 
   <section class="card-panel" id="p-missions">
-    <div class="phead"><h2>Missions</h2></div>
+    <div class="phead">
+      <h2>Missions</h2>
+      <span class="count" id="mission-count"></span>
+    </div>
     <p class="note">
       Every recorded run, newest first. Each has a page of its own — the scoreboard, the map with its
       replay, and everything that happened — worth pasting into chat. Runs under fifty events are left


### PR DESCRIPTION
Forty-three rows reading `Kolkhi_Test · Caucasus` told you which runs existed and nothing about which to open.

**Before**
```
Kolkhi_Test   Caucasus · Aug 1 · 59m 54s    7646 events
```

**After**
```
Kolkhi_Test                          Caucasus · Aug 1, 2026
KILLS   SORTIES   RAN FOR   EVENTS
   87       222   59m 54s     7646
★ a 31.1 nm shot by Blue AI
Flown by Meekss
```

## Flown by

There is no login, so *"the ones I was in"* has to be asked as a question — but the answer is remembered in `localStorage`, so it only has to be answered once. The picker is built from the runs themselves: whoever has flown is whoever you can filter by. Selecting Meekss narrows 43 runs to the 16 he was in, and survives a reload.

## The highlight, and what the data taught me

Each run gets one line: a burst of three inside a minute, an ace's night, a long shot, or simply who led. A human's moment wins over an AI's **even when it is smaller** — a night where a real pilot took two aircraft is a better story than one where a coalition took ninety.

The first version allowed AI bursts, and the result was useless:

```
highlight kinds across 43 missions: {multikill: 37, topscorer: 1, none: 5}
  m40 → AI-Unit (blue) took 12 in 24s
  m39 → AI-Unit (blue) took 14 in 57s
  m38 → AI-Unit (blue) took 4 in 29s
```

Thirty-seven missions reading the same way is the *opposite* of telling them apart. The synthetic AI players pool an entire coalition, so a "burst" is just the blue air force having a busy minute — not a moment. **Bursts and totals are now humans only.** A long shot survives for AI, because one missile flying thirty miles is one event whoever is credited with it:

```
highlight kinds across 43 missions: {longshot: 32, topscorer: 1, none: 10}
  m40 → a 31.1 nm shot by Blue AI
  m39 → a 45.7 nm shot by Blue AI
  m37 → Meekss led with 3          ← the human's night wins
  m35 → a 50.1 nm shot by Blue AI
```

## Cost

Three extra queries and one pass over every kill (~2,500 rows, one scan — not a query per mission, which would be 130 round trips). That is real weight, so it is its own `missionIndex` resolver rather than more load on `missions`, which the badge shelf, the flight log and the hero all fetch on every page load. Measured at ~1.0s for the whole index.

Verified in the browser: 43 cards, live run badged, filter 43 → 16 and back, choice persisted across reload, highlights on 33 of them, and at 375px all four stats still fit one row with no horizontal scroll. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)