### PR TITLE
Make the mission task panel usable

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -1371,3 +1371,16 @@ a.brand:hover b { text-decoration: underline; }
   font: inherit;
   font-size: 0.8125rem;
 }
+
+/* ---- mission task filters ---- */
+/* A running mission can export well over a thousand tasks. The tally turns
+   that wall into a sentence, and the chips carry their own totals so the
+   filter says what it would show before it is used. */
+.tally {
+  margin: 0 0 0.8rem;
+  color: var(--text-dim);
+  font-size: 0.8125rem;
+}
+.tally b { color: var(--text); font-weight: 600; font-variant-numeric: tabular-nums; }
+#task-state button b { font-variant-numeric: tabular-nums; opacity: 0.65; font-weight: 500; }
+#task-state button.on b { opacity: 0.8; }

--- a/web/app.js
+++ b/web/app.js
@@ -88,7 +88,12 @@ const state = {
     "p-aircraft": { key: "sorties", dir: -1 },
     "p-weapons": { key: "shots", dir: -1 },
     "p-grades": { key: "missionTime", dir: -1 },
+    tasks: { key: "points", dir: -1 },
+    "player-tasks": { key: "points", dir: -1 },
   },
+  // Which state the mission-task panel is narrowed to, and to whose tasks.
+  taskState: "all",
+  taskPilot: "",
 };
 
 // The synthetic AI players are stored under a machine-ish name. They are real
@@ -777,7 +782,7 @@ function drawMissions(missions) {
 // answered once.
 function fillPilotFilter(missions) {
   const sel = el("pilot-filter");
-  if (!sel || sel.dataset.filled) return;
+  if (!sel) return;
 
   const seen = new Map();
   for (const m of missions) {
@@ -785,7 +790,12 @@ function fillPilotFilter(missions) {
   }
   if (!seen.size) return;
 
-  sel.dataset.filled = "1";
+  // Rebuilt when the roster changes, not once: somebody's first sortie should
+  // put them in the picker on the next poll.
+  const signature = [...seen.keys()].sort().join(",");
+  if (sel.dataset.signature === signature) return;
+  sel.dataset.signature = signature;
+
   sel.innerHTML =
     `<option value="">Anyone</option>` +
     [...seen.entries()]
@@ -1203,7 +1213,27 @@ function drawRecords(r) {
 
 // Mission tasks, when the mission exports any. The panel stays hidden rather
 // than showing an empty table on servers whose missions say nothing.
-function drawTasks(tableID, panelID, tasks) {
+// The mission's own state word, reduced to the three that matter.
+//
+// State is free text by contract -- the mission says where a task stands and
+// overlord displays it without acting on it -- so the filter groups rather than
+// matches exactly. Anything that is not plainly finished or plainly lost is
+// still in play.
+function taskState(state) {
+  const v = (state || "").toLowerCase();
+  if (["done", "complete", "completed", "success", "succeeded"].includes(v)) return "done";
+  if (["failed", "fail", "lost"].includes(v)) return "failed";
+  return "active";
+}
+
+// maxTasks caps what reaches the DOM. The current mission exports 1,414 tasks;
+// rendering all of them makes a wall nobody reads and a page that janks on
+// every poll. The count line says what was left out.
+const maxTasks = 200;
+
+// Mission tasks, when the mission exports any. The panel stays hidden rather
+// than showing an empty table on servers whose missions say nothing.
+function drawTasks(tableID, panelID, tasks, redraw = draw) {
   const panel = el(panelID);
   if (!panel) return;
   if (!tasks || !tasks.length) {
@@ -1212,19 +1242,118 @@ function drawTasks(tableID, panelID, tasks) {
   }
   panel.hidden = false;
 
-  el(tableID).innerHTML =
-    `<thead><tr><th>Task</th><th>State</th><th>Pilot</th><th class="num">Points</th></tr></thead><tbody>` +
-    tasks
-      .map(
-        (t) => `<tr>
-          <td class="name">${esc(t.title || t.taskKey)}</td>
-          <td><span class="ev ${t.state === "done" ? "ev-kill" : t.state === "failed" ? "ev-loss" : ""}">${esc(t.state || "—")}</span></td>
-          <td>${esc(t.playerName || "—")}</td>
-          <td class="num">${num(t.points)}</td>
-        </tr>`
-      )
-      .join("") +
-    `</tbody>`;
+  fillTaskPilots(tasks);
+
+  // Counts are of everything the mission exported, not of what survives the
+  // filter: a chip that reported its own filtered total would always read the
+  // same number as the table beside it.
+  const tally = { all: tasks.length, done: 0, failed: 0, active: 0 };
+  let earned = 0;
+  for (const t of tasks) {
+    const s = taskState(t.state);
+    tally[s]++;
+    if (s === "done") earned += t.points || 0;
+  }
+  labelTaskChips(tally);
+
+  const rows = tasks
+    .filter((t) => state.taskState === "all" || taskState(t.state) === state.taskState)
+    .filter((t) => {
+      if (!state.taskPilot) return true;
+      if (state.taskPilot === "none") return !t.playerName;
+      return t.playerID === state.taskPilot;
+    })
+    .filter((t) => matches([t.title, t.taskKey, t.playerName]));
+
+  // The tally and count belong to the filtered panel; the pilot page's own
+  // task table has neither and simply skips them.
+  const tallyEl = el("task-tally");
+  if (tallyEl) {
+    tallyEl.innerHTML =
+      `<b>${num(tally.done)}</b> done · <b>${num(tally.failed)}</b> failed · ` +
+      `<b>${num(tally.active)}</b> still running · <b>${num(earned)}</b> points banked`;
+  }
+
+  const shown = rows.slice(0, maxTasks);
+  const countEl = el("task-count");
+  if (countEl) {
+    countEl.textContent =
+      rows.length > shown.length
+        ? `showing ${shown.length} of ${num(rows.length)}`
+        : rows.length === tally.all
+          ? ""
+          : `${num(rows.length)} of ${num(tally.all)}`;
+  }
+
+  render(
+    tableID,
+    [
+      { label: "Task", key: "title" },
+      { label: "State", key: "state" },
+      { label: "Pilot", key: "playerName" },
+      { label: "Points", key: "points", num: true },
+    ],
+    sortRows(shown, tableID),
+    (t) => {
+      const s = taskState(t.state);
+      return `<tr>
+        <td class="name">${esc(t.title || t.taskKey)}</td>
+        <td><span class="ev ${s === "done" ? "ev-kill" : s === "failed" ? "ev-loss" : ""}">${esc(t.state || "—")}</span></td>
+        <td>${t.playerID ? pref(t.playerID, t.playerName) : `<span class="zero">mission</span>`}</td>
+        <td class="num">${num(t.points)}</td>
+      </tr>`;
+    },
+    redraw
+  );
+}
+
+// Chip labels carry their own totals, so the filter says what it would show
+// before it is used.
+function labelTaskChips(tally) {
+  const group = el("task-state");
+  if (!group) return;
+  for (const btn of group.querySelectorAll("button")) {
+    const k = btn.dataset.tstate;
+    const word = btn.dataset.label || btn.textContent.trim();
+    btn.dataset.label = word;
+    btn.innerHTML = `${esc(word)} <b>${num(tally[k] ?? 0)}</b>`;
+  }
+}
+
+// Whose tasks these are. Most are the mission's own rather than any pilot's,
+// so that gets an option of its own instead of being lumped under "anyone".
+// Rebuilt whenever the set of names changes rather than once, because it does
+// change: the first draw of a fresh mission has no pilots in it at all, and
+// switching to all time brings in every pilot who has ever been given a task.
+// Filling it once left the picker permanently stuck on that first empty answer.
+function fillTaskPilots(tasks) {
+  const sel = el("task-pilot");
+  if (!sel) return;
+
+  const seen = new Map();
+  let missionWide = false;
+  for (const t of tasks) {
+    if (t.playerID) seen.set(t.playerID, t.playerName);
+    else missionWide = true;
+  }
+  if (!seen.size && !missionWide) return;
+
+  const signature = (missionWide ? "m|" : "") + [...seen.keys()].sort().join(",");
+  if (sel.dataset.signature === signature) return;
+  sel.dataset.signature = signature;
+
+  sel.innerHTML =
+    `<option value="">Anyone</option>` +
+    (missionWide ? `<option value="none">The mission itself</option>` : "") +
+    [...seen.entries()]
+      .sort((a, b) => a[1].localeCompare(b[1]))
+      .map(([id, name]) => `<option value="${esc(id)}">${esc(playerLabel(name))}</option>`)
+      .join("");
+
+  // A pilot who is no longer in the list cannot stay selected, or the panel
+  // would silently show nothing with no way to tell why.
+  if (state.taskPilot && state.taskPilot !== "none" && !seen.has(state.taskPilot)) state.taskPilot = "";
+  sel.value = state.taskPilot;
 }
 
 // Scenery. Deliberately light, deliberately apart from the real figures, and
@@ -1715,7 +1844,8 @@ function drawPlayer() {
     "p-player-tasks",
     (state.tasks || []).filter(
       (t) => (t.playerID ? t.playerID === p.playerID : t.playerName === p.playerName)
-    )
+    ),
+    drawPlayer
   );
 
   const matchHay = (m) => matches([...unitHay(m.unitType), ...unitHay(m.targetType)]);
@@ -2197,6 +2327,15 @@ chips("scope", "scope", (v) => {
 
 if (PAGE === "dashboard" || PAGE === "mission" || PAGE === "weapons" || PAGE === "log") {
   chips("weapon-class", "class", (v) => (state.weaponClass = v));
+
+  // Both narrow what is already loaded, so they redraw rather than refetch.
+  chips("task-state", "tstate", (v) => (state.taskState = v));
+  if (el("task-pilot")) {
+    el("task-pilot").addEventListener("change", (e) => {
+      state.taskPilot = e.target.value;
+      draw();
+    });
+  }
 
   // These two change what the query asks for, so they refetch rather than redraw.
   chips("log-filter", "ev", (v) => {

--- a/web/index.html
+++ b/web/index.html
@@ -127,9 +127,22 @@
   </div>
 
   <section class="card-panel" id="p-tasks" hidden>
-    <div class="phead"><h2>Mission tasks</h2></div>
+    <div class="phead">
+      <h2>Mission tasks</h2>
+      <div class="chips" id="task-state" role="group" aria-label="Filter by state">
+        <button type="button" data-tstate="all" class="on">All</button>
+        <button type="button" data-tstate="done">Done</button>
+        <button type="button" data-tstate="failed">Failed</button>
+        <button type="button" data-tstate="active">Active</button>
+      </div>
+      <label class="pick">Whose
+        <select id="task-pilot"><option value="">Anyone</option></select>
+      </label>
+      <span class="count" id="task-count"></span>
+    </div>
     <p class="note">Set and scored by the mission itself, straight from its own scripting.</p>
-    <div class="tw"><table id="tasks" class="grid"></table></div>
+    <p class="tally" id="task-tally"></p>
+    <div class="tw tw-tall"><table id="tasks" class="grid"></table></div>
   </section>
 
 </main>

--- a/web/mission.html
+++ b/web/mission.html
@@ -139,9 +139,22 @@
   </div>
 
   <section class="card-panel" id="p-tasks" hidden>
-    <div class="phead"><h2>Mission tasks</h2></div>
+    <div class="phead">
+      <h2>Mission tasks</h2>
+      <div class="chips" id="task-state" role="group" aria-label="Filter by state">
+        <button type="button" data-tstate="all" class="on">All</button>
+        <button type="button" data-tstate="done">Done</button>
+        <button type="button" data-tstate="failed">Failed</button>
+        <button type="button" data-tstate="active">Active</button>
+      </div>
+      <label class="pick">Whose
+        <select id="task-pilot"><option value="">Anyone</option></select>
+      </label>
+      <span class="count" id="task-count"></span>
+    </div>
     <p class="note">Set and scored by the mission itself, straight from its own scripting.</p>
-    <div class="tw"><table id="tasks" class="grid"></table></div>
+    <p class="tally" id="task-tally"></p>
+    <div class="tw tw-tall"><table id="tasks" class="grid"></table></div>
   </section>
 
   <section class="card-panel" id="p-collateral">


### PR DESCRIPTION
A running mission exports a snapshot of every task on every poll. This server's has **1,414** of them, and all 1,414 went into the DOM as an unsorted, unfiltered, unsummarised wall.

**Now:**

```
Mission tasks   [All 1414] [Done 543] [Failed 597] [Active 274]   Whose ▾   showing 200 of 1414
543 done · 597 failed · 274 still running · 41,480 points banked
```

- **State chips** carrying their own totals, so the filter says what it would show *before* you use it. The totals are of everything exported, not of what survives the filter — a chip reporting its own filtered count would always read the same number as the table beside it.
- **Whose** — Anyone / The mission itself / each pilot. Most tasks belong to the mission rather than a person (1,412 of 1,414), so that gets an option of its own instead of being lumped under "anyone".
- **Every column sorts**, via the same `render()` the other tables use. The panel was building raw `innerHTML` and had none.
- **The global search applies**, which it also did not before.
- **200 rows reach the DOM at most**, with the count line saying what was left out. Fourteen hundred is a wall nobody reads and a page that janks on every poll.
- Pilot names are **links** now. They always were pilots.

State is free text by contract — the mission says where a task stands and overlord displays it without acting on it — so the filter *groups* rather than matches: `done/complete/completed/success` → done, `failed/fail/lost` → failed, anything else is still in play.

## One bug found in testing

The pilot picker filled once and never again. A fresh mission's first draw has no pilots in it at all, so the list was built empty and *stayed* empty — switching to All time brought in 1,414 tasks including Meekss's and still offered nobody. It now rebuilds when the set of names changes, and clears a selection for a pilot who is no longer in the list rather than silently showing nothing.

## Verified

All time (1,414 tasks): chips read 1414/543/597/274, tally matches, cap reads `showing 200 of 1414`. Failed → `showing 200 of 597`. Meekss → exactly his 2 tasks, `2 of 1414`. The mission itself → 1,412. All four columns sort. Mission recap (27 tasks): chips 27/15/5/7, failed → `5 of 27`, no cap needed. Player page: keeps sorting, correctly has no filters since it is already narrowed to one pilot. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)