### PR TITLE
Read the LSO's grade and chart the recoveries

### DIFF
--- a/controllers/aggregates.go
+++ b/controllers/aggregates.go
@@ -406,6 +406,8 @@ func GetLandingGrades(limit int, missionID *uint) ([]*models.LandingGrade, error
 	err := initializers.DB.Model(&models.Event{}).
 		Scopes(scopeMission(missionID)).
 		Select(`players.player_name AS player_name,
+			events.player_id AS player_id,
+			events.mission_id AS mission_id,
 			units.type AS unit_type,
 			events.place AS place,
 			events.comment AS grade,
@@ -423,6 +425,7 @@ func GetLandingGrades(limit int, missionID *uint) ([]*models.LandingGrade, error
 
 	result := make([]*models.LandingGrade, 0, len(rows))
 	for i := range rows {
+		rows[i].ReadLSO()
 		result = append(result, &rows[i])
 	}
 

--- a/graph/helpers.go
+++ b/graph/helpers.go
@@ -5,7 +5,10 @@ package graph
 // commented graveyard at the bottom, which deleted parseOptionalID the first
 // time the schema was regenerated after it was added.
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 // parseOptionalID turns an optional GraphQL ID into a *uint, treating absent,
 // empty and unparseable all as "not narrowed" rather than as errors.
@@ -19,4 +22,13 @@ func parseOptionalID(s *string) *uint {
 	}
 	v := uint(parsed)
 	return &v
+}
+
+// optionalID renders a nullable database id as a nullable GraphQL one.
+func optionalID(id *uint) *string {
+	if id == nil {
+		return nil
+	}
+	s := fmt.Sprintf("%v", *id)
+	return &s
 }

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -39,6 +39,25 @@ func (r *killRecordResolver) PlayerID(ctx context.Context, obj *models.KillRecor
 	return fmt.Sprintf("%v", obj.PlayerID), nil
 }
 
+// PlayerID is the resolver for the playerID field.
+func (r *landingGradeResolver) PlayerID(ctx context.Context, obj *models.LandingGrade) (*string, error) {
+	return optionalID(obj.PlayerID), nil
+}
+
+// MissionID is the resolver for the missionID field.
+func (r *landingGradeResolver) MissionID(ctx context.Context, obj *models.LandingGrade) (*string, error) {
+	return optionalID(obj.MissionID), nil
+}
+
+// optionalID renders a nullable database id as a nullable GraphQL one.
+func optionalID(id *uint) *string {
+	if id == nil {
+		return nil
+	}
+	s := fmt.Sprintf("%v", *id)
+	return &s
+}
+
 // ID is the resolver for the id field.
 func (r *missionResolver) ID(ctx context.Context, obj *models.MissionSummary) (string, error) {
 	return fmt.Sprintf("%v", obj.MissionID), nil
@@ -393,6 +412,9 @@ func (r *Resolver) Favourite() generated.FavouriteResolver { return &favouriteRe
 // KillRecord returns generated.KillRecordResolver implementation.
 func (r *Resolver) KillRecord() generated.KillRecordResolver { return &killRecordResolver{r} }
 
+// LandingGrade returns generated.LandingGradeResolver implementation.
+func (r *Resolver) LandingGrade() generated.LandingGradeResolver { return &landingGradeResolver{r} }
+
 // Mission returns generated.MissionResolver implementation.
 func (r *Resolver) Mission() generated.MissionResolver { return &missionResolver{r} }
 
@@ -457,6 +479,7 @@ type (
 	eventResolver               struct{ *Resolver }
 	favouriteResolver           struct{ *Resolver }
 	killRecordResolver          struct{ *Resolver }
+	landingGradeResolver        struct{ *Resolver }
 	missionResolver             struct{ *Resolver }
 	missionEntryResolver        struct{ *Resolver }
 	missionHighlightResolver    struct{ *Resolver }

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -49,15 +49,6 @@ func (r *landingGradeResolver) MissionID(ctx context.Context, obj *models.Landin
 	return optionalID(obj.MissionID), nil
 }
 
-// optionalID renders a nullable database id as a nullable GraphQL one.
-func optionalID(id *uint) *string {
-	if id == nil {
-		return nil
-	}
-	s := fmt.Sprintf("%v", *id)
-	return &s
-}
-
 // ID is the resolver for the id field.
 func (r *missionResolver) ID(ctx context.Context, obj *models.MissionSummary) (string, error) {
 	return fmt.Sprintf("%v", obj.MissionID), nil

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -553,13 +553,36 @@ type MissionTask {
     updatedAt: Time!
 }
 
-"One graded landing. The grade is free text as DCS reported it."
+"""
+One carrier recovery, as the Landing Signal Officer graded it.
+
+DCS reports the whole pass as a single line of LSO shorthand —
+`LSO: GRADE:C : LNFIW  WIRE# 2`. Overlord reads it into parts so it can be
+scored, charted and compared rather than only displayed.
+"""
 type LandingGrade {
     playerName: String
+    playerID: ID
+    missionID: ID
     unitType: String
     place: String
+    "The LSO's line exactly as DCS wrote it."
     grade: String
     missionTime: Float!
+
+    "The grade token alone: _OK_, OK, (OK), ---, B, C or WO."
+    mark: String!
+    "What that grade is worth on the Navy's four-point scale."
+    score: Float!
+    """
+    False for a landing DCS did not grade this way, or a grade we do not
+    recognise. Such a pass must not be averaged in as a zero.
+    """
+    scored: Boolean!
+    "The wire caught, 1 to 4. Zero is a bolter — it caught none."
+    wire: Int!
+    "The LSO's remarks in words. Empty for a clean pass."
+    deviations: [String!]!
 }
 
 type CoalitionKills {

--- a/models/lso.go
+++ b/models/lso.go
@@ -1,0 +1,171 @@
+package models
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Parsing the LSO's grade.
+//
+// DCS reports a carrier recovery as one string in the Landing Signal Officer's
+// own shorthand:
+//
+//	LSO: GRADE:_OK_ : WIRE# 4
+//	LSO: GRADE:C : LNFIW  WIRE# 2
+//	LSO: GRADE:--- : (EGTL)  LNFIW  WIRE# 3
+//
+// Displayed raw it is unreadable to anyone who has not flown the pattern, and
+// unusable for anything but reading. Split into a grade, a wire and a list of
+// deviations it becomes a score you can average, a distribution you can chart,
+// and a pass you can compare with the one before it.
+//
+// Parsed here rather than in the browser because it is a property of the
+// recording, not of one page: the chart, the table and any future export should
+// all agree about what a pass was worth.
+
+var (
+	lsoGrade = regexp.MustCompile(`GRADE:\s*([^\s:]+)`)
+	lsoWire  = regexp.MustCompile(`WIRE#\s*(\d+)`)
+)
+
+// lsoScores are the Navy's grades and what each is worth. A perfect pass is
+// four points; a cut pass -- one the LSO judged unsafe -- is one.
+//
+// Values follow the standard USN scale so an average here means what it means
+// in a ready room. Anything unrecognised scores nothing and is left named.
+var lsoScores = map[string]float64{
+	"_OK_": 4.0, // perfect
+	"OK":   3.0, // no deviations worth mentioning
+	"(OK)": 2.5, // fair
+	"---":  2.0, // no grade
+	"B":    2.0, // bolter -- missed the wires, not a judgement of the pass
+	"C":    1.0, // cut: unsafe
+	"WO":   0.0, // wave off
+}
+
+// lsoWords expands the LSO's abbreviations. Only position and error codes are
+// listed; the parser leaves anything else as it found it rather than guessing.
+var lsoWords = map[string]string{
+	"LU": "lined up left", "LUR": "lined up right", "LUL": "lined up left",
+	"OS": "overshoot", "US": "undershoot",
+	"H": "high", "LO": "low", "F": "fast", "SLO": "slow",
+	"DL": "drifted left", "DR": "drifted right",
+	"P": "power", "N": "nose", "LL": "landed left", "LR": "landed right",
+	"EG": "eased gun", "TL": "too long", "AR": "at the ramp", "IC": "in close",
+	"IM": "in the middle", "X": "at the start", "IW": "in the wires",
+	"LNF": "not enough line-up correction", "TMRD": "too much rate of descent",
+	"NSU": "not set up", "WOP": "wave-off pattern", "LOAR": "low at the ramp",
+	"LOIC": "low in close", "LOIM": "low in the middle",
+}
+
+// LSOPass is one carrier recovery, read out of the LSO's shorthand.
+type LSOPass struct {
+	// Grade is the token itself: _OK_, OK, (OK), ---, B, C, WO.
+	Grade string
+	// Score is what that grade is worth on the four-point scale, and Graded
+	// says whether the token was one we know. An unrecognised grade scores
+	// zero, which is not the same as having earned zero.
+	Score  float64
+	Graded bool
+	// Wire caught, 1 to 4. Zero when the pass caught none, which is a bolter.
+	Wire int
+	// Deviations are the LSO's remarks, expanded where the abbreviation is
+	// known. Empty for a clean pass.
+	Deviations []string
+}
+
+// ParseLSO reads a DCS landing-quality string. A string that carries no grade
+// at all returns ok false: it is a landing DCS graded some other way, or none.
+func ParseLSO(comment string) (LSOPass, bool) {
+	if comment == "" {
+		return LSOPass{}, false
+	}
+
+	// Indices, not the matched text: the grade sits partway into the string, so
+	// slicing by the match's length rather than its end takes a bite out of
+	// "LSO: GRADE:" and leaves it in the remarks.
+	m := lsoGrade.FindStringSubmatchIndex(comment)
+	if m == nil {
+		return LSOPass{}, false
+	}
+
+	pass := LSOPass{Grade: comment[m[2]:m[3]]}
+	if score, known := lsoScores[pass.Grade]; known {
+		pass.Score = score
+		pass.Graded = true
+	}
+
+	if w := lsoWire.FindStringSubmatch(comment); w != nil {
+		pass.Wire, _ = strconv.Atoi(w[1])
+	}
+
+	// What is left between the grade and the wire is the LSO's remarks. The
+	// case and brackets carry severity -- lower case is minor, upper case
+	// major, underscores gross -- which is preserved by expanding the letters
+	// and leaving the wrapping alone.
+	rest := comment[m[1]:]
+	rest = lsoWire.ReplaceAllString(rest, "")
+	rest = strings.TrimLeft(rest, ": ")
+
+	for _, token := range strings.Fields(rest) {
+		if word := expandLSO(token); word != "" {
+			pass.Deviations = append(pass.Deviations, word)
+		}
+	}
+
+	return pass, true
+}
+
+// expandLSO turns one remark into words, keeping the severity its wrapping
+// carries. Unknown codes come back as they went in: a remark nobody can read
+// is still better than one silently dropped.
+func expandLSO(token string) string {
+	trimmed := strings.Trim(token, "_()")
+	if trimmed == "" {
+		return ""
+	}
+
+	severity := ""
+	switch {
+	case strings.HasPrefix(token, "_"):
+		severity = "gross "
+	case strings.HasPrefix(token, "("):
+		severity = "a little "
+	}
+
+	return severity + decodeLSO(strings.ToUpper(trimmed))
+}
+
+// decodeLSO reads one remark, which the LSO writes as run-together codes:
+// LNFIW is LNF then IW, "not enough line-up correction in the wires"; TMRDIC
+// is TMRD then IC. Longest match first, so LOAR is read as itself rather than
+// as LO followed by AR.
+//
+// A code nobody recognises comes back as it went in. A remark that cannot be
+// read is still better than one silently dropped.
+func decodeLSO(code string) string {
+	if word, known := lsoWords[code]; known {
+		return word
+	}
+
+	var out []string
+	for i := 0; i < len(code); {
+		matched := ""
+		for size := len(code) - i; size > 0; size-- {
+			if word, known := lsoWords[code[i:i+size]]; known {
+				matched = word
+				i += size
+				break
+			}
+		}
+		if matched == "" {
+			// Nothing here is a code. Keep the rest verbatim and stop.
+			out = append(out, code[i:])
+			break
+		}
+		out = append(out, matched)
+	}
+
+	return strings.Join(out, " ")
+}

--- a/models/lso_test.go
+++ b/models/lso_test.go
@@ -1,0 +1,73 @@
+package models
+
+import "testing"
+
+// Strings taken verbatim from the recorded database, so the parser is tested
+// against what DCS actually writes rather than what the manual says it does.
+func TestParseLSO(t *testing.T) {
+	cases := []struct {
+		in     string
+		grade  string
+		score  float64
+		wire   int
+		devs   int
+		graded bool
+	}{
+		{"LSO: GRADE:_OK_ : WIRE# 4", "_OK_", 4.0, 4, 0, true},
+		{"LSO: GRADE:C : LNFIW  WIRE# 2", "C", 1.0, 2, 1, true},
+		{"LSO: GRADE:--- : (EGTL)  WIRE# 4", "---", 2.0, 4, 1, true},
+		{"LSO: GRADE:C : _TMRDIC_  (EGTL)  LNFIW  WIRE# 1", "C", 1.0, 1, 3, true},
+		{"LSO: GRADE:--- : LOAR  (EGTL)  WIRE# 2", "---", 2.0, 2, 2, true},
+		// A bolter catches no wire, which is not the same as wire zero being
+		// missing from the string.
+		{"LSO: GRADE:B :", "B", 2.0, 0, 0, true},
+	}
+
+	for _, c := range cases {
+		got, ok := ParseLSO(c.in)
+		if !ok {
+			t.Errorf("ParseLSO(%q) reported no grade", c.in)
+			continue
+		}
+		if got.Grade != c.grade {
+			t.Errorf("ParseLSO(%q) grade = %q, want %q", c.in, got.Grade, c.grade)
+		}
+		if got.Score != c.score {
+			t.Errorf("ParseLSO(%q) score = %v, want %v", c.in, got.Score, c.score)
+		}
+		if got.Graded != c.graded {
+			t.Errorf("ParseLSO(%q) graded = %v, want %v", c.in, got.Graded, c.graded)
+		}
+		if got.Wire != c.wire {
+			t.Errorf("ParseLSO(%q) wire = %d, want %d", c.in, got.Wire, c.wire)
+		}
+		if len(got.Deviations) != c.devs {
+			t.Errorf("ParseLSO(%q) deviations = %v, want %d of them", c.in, got.Deviations, c.devs)
+		}
+	}
+}
+
+// A landing DCS graded some other way, or not at all, must not come back as a
+// zero-scored pass -- that would drag every average down with phantom traps.
+func TestParseLSOIgnoresNonCarrierLandings(t *testing.T) {
+	for _, in := range []string{"", "landed", "Airfield landing at Batumi"} {
+		if _, ok := ParseLSO(in); ok {
+			t.Errorf("ParseLSO(%q) claimed to be a graded pass", in)
+		}
+	}
+}
+
+// An unknown grade keeps its name and is excluded from scoring rather than
+// counted as a zero.
+func TestParseLSOUnknownGrade(t *testing.T) {
+	got, ok := ParseLSO("LSO: GRADE:?? : WIRE# 3")
+	if !ok {
+		t.Fatal("expected a parse")
+	}
+	if got.Grade != "??" || got.Graded {
+		t.Errorf("got grade %q graded=%v, want %q ungraded", got.Grade, got.Graded, "??")
+	}
+	if got.Wire != 3 {
+		t.Errorf("wire = %d, want 3", got.Wire)
+	}
+}

--- a/models/summary.go
+++ b/models/summary.go
@@ -362,11 +362,38 @@ type SceneryCount struct {
 
 // LandingGrade is one graded landing, as DCS reported it.
 type LandingGrade struct {
-	PlayerName  string
-	UnitType    string
-	Place       string
+	PlayerName string
+	UnitType   string
+	Place      string
+	// Grade is the LSO's line exactly as DCS wrote it.
 	Grade       string
 	MissionTime float64
+	// PlayerID links to the pilot when the landing was flown by a known one.
+	PlayerID *uint
+	MissionID *uint
+	// The rest is Grade read out into parts: see ParseLSO. Mark is the grade
+	// token, Score what it is worth out of four, Wire the one caught, and
+	// Deviations the LSO's remarks in words. Scored is false for a landing
+	// DCS did not grade this way, which must not be averaged as a zero.
+	Mark       string
+	Score      float64
+	Scored     bool
+	Wire       int
+	Deviations []string
+}
+
+// ReadLSO fills in the parsed fields from the raw grade. Called once where the
+// rows are built, so every consumer sees the same reading.
+func (g *LandingGrade) ReadLSO() {
+	pass, ok := ParseLSO(g.Grade)
+	if !ok {
+		return
+	}
+	g.Mark = pass.Grade
+	g.Score = pass.Score
+	g.Scored = pass.Graded
+	g.Wire = pass.Wire
+	g.Deviations = pass.Deviations
 }
 
 // CoalitionKills is a kill tally for one coalition.

--- a/routers/graphql.go
+++ b/routers/graphql.go
@@ -105,6 +105,7 @@ func GraphQLHandler() {
 	// past on the way to the one they wanted.
 	mux.HandleFunc("/missions", servePage("missions.html"))
 	mux.HandleFunc("/weapons", servePage("weapons.html"))
+	mux.HandleFunc("/landings", servePage("landings.html"))
 	mux.HandleFunc("/log", servePage("log.html"))
 
 	// The playground moves off / now that the dashboard lives there. It stays

--- a/web/app.css
+++ b/web/app.css
@@ -1405,3 +1405,72 @@ a.brand:hover b { text-decoration: underline; }
 .pager button:disabled { opacity: 0.4; cursor: default; }
 .pager button:disabled:hover { color: var(--text-dim); background: var(--surface); }
 .pg-at { color: var(--text-dim); font-size: 0.8125rem; font-variant-numeric: tabular-nums; }
+
+/* ---- landings ---- */
+.lso-head { display: flex; flex-wrap: wrap; gap: 0.3rem 2rem; margin: 0 0 1.1rem; }
+.lso-head div { display: flex; flex-direction: column; gap: 0.1rem; }
+.lso-head dt {
+  color: var(--text-faint);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.lso-head dd { margin: 0; font-size: 1.35rem; font-weight: 600; font-variant-numeric: tabular-nums; }
+.lso-of { color: var(--text-faint); font-size: 0.8125rem; font-weight: 400; }
+
+.dist-title {
+  margin: 0 0 0.4rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+/* One bar per distribution, segments sized by share. Reading a shape is the
+   whole point, so the segments carry their counts and the key names them. */
+.dist { display: flex; height: 1.6rem; border-radius: var(--radius-sm); overflow: hidden; }
+.dist-seg {
+  display: grid;
+  place-items: center;
+  min-width: 1.6rem;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.dist-best { background: var(--ok); }
+.dist-ok { background: color-mix(in srgb, var(--ok) 62%, var(--neutral)); }
+.dist-mid { background: var(--neutral); }
+.dist-bad { background: var(--red); }
+
+.dist-key {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
+  margin: 0.5rem 0 1.2rem;
+  padding: 0;
+  list-style: none;
+  color: var(--text-dim);
+  font-size: 0.75rem;
+}
+.dist-key li { display: flex; align-items: center; gap: 0.35rem; }
+.dist-key i { width: 0.6rem; height: 0.6rem; border-radius: 2px; }
+.dist-key b { color: var(--text); font-variant-numeric: tabular-nums; }
+
+.dist-more { margin: 0.2rem 0 0; font-size: 0.8125rem; }
+
+.lso-mark {
+  display: inline-block;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.lso-best { background: var(--ok); color: #fff; }
+.lso-ok { background: color-mix(in srgb, var(--ok) 62%, var(--neutral)); color: #fff; }
+.lso-mid { background: var(--surface-2); color: var(--text-dim); }
+.lso-bad { background: var(--red); color: #fff; }
+.lso-devs { color: var(--text-dim); font-size: 0.8125rem; }

--- a/web/app.css
+++ b/web/app.css
@@ -560,7 +560,9 @@ table.hm thead th { vertical-align: bottom; }
 /* ---- tables ---- */
 
 .tw { overflow: auto; }
-.tw-tall { max-height: 30rem; }
+/* .tw-tall is gone: long tables paginate now rather than scrolling inside a
+   fixed box. A box that scrolls hides how much there is and puts a second
+   scrollbar inside the page's own. */
 
 /* The bottom panels are heavy (the log alone is 200 rows, redrawn every poll)
    and sit below the fold on every viewport, so the browser may skip rendering
@@ -1384,3 +1386,22 @@ a.brand:hover b { text-decoration: underline; }
 .tally b { color: var(--text); font-weight: 600; font-variant-numeric: tabular-nums; }
 #task-state button b { font-variant-numeric: tabular-nums; opacity: 0.65; font-weight: 500; }
 #task-state button.on b { opacity: 0.8; }
+
+/* ---- pagination ---- */
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  margin-top: 0.7rem;
+}
+.pager:empty { display: none; }
+.pager button {
+  min-width: 2rem;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.875rem;
+  line-height: 1;
+}
+.pager button:disabled { opacity: 0.4; cursor: default; }
+.pager button:disabled:hover { color: var(--text-dim); background: var(--surface); }
+.pg-at { color: var(--text-dim); font-size: 0.8125rem; font-variant-numeric: tabular-nums; }

--- a/web/app.js
+++ b/web/app.js
@@ -94,6 +94,8 @@ const state = {
   // Which state the mission-task panel is narrowed to, and to whose tasks.
   taskState: "all",
   taskPilot: "",
+  // Where each paginated table is. Keyed by table id; absent means page one.
+  page: {},
 };
 
 // The synthetic AI players are stored under a machine-ish name. They are real
@@ -338,12 +340,71 @@ function sortRows(rows, table) {
 // redraw is what a sort click re-runs. It defaults to the dashboard, since the
 // player page renders a different set of tables and must not redraw the one
 // behind it.
+// PAGE_ROWS is how many rows a table shows at once.
+//
+// Long tables used to scroll inside a fixed-height box, which hides how much
+// there is, cannot be linked to, and puts a second scrollbar inside the page's
+// own. A page count says what you have and where you are in it.
+const PAGE_ROWS = 50;
+
+// pageOf returns the slice on show and the numbers to describe it.
+//
+// The index is clamped rather than trusted: a filter can shrink the set under
+// your feet -- narrowing 1,414 tasks to 3 while you are on page 12 -- and an
+// out-of-range page renders an empty table with no hint of why.
+function pageOf(table, rows) {
+  const pages = Math.max(1, Math.ceil(rows.length / PAGE_ROWS));
+  const at = Math.min(Math.max(0, state.page[table] || 0), pages - 1);
+  state.page[table] = at;
+
+  const from = at * PAGE_ROWS;
+  return { rows: rows.slice(from, from + PAGE_ROWS), at, pages, from, total: rows.length };
+}
+
+// The pager. Rendered after the table rather than inside it, since a table's
+// own markup has nowhere legitimate for controls.
+function pager(table, p, redraw) {
+  const host = el(`${table}-pager`);
+  if (!host) return;
+
+  if (p.pages <= 1) {
+    host.innerHTML = "";
+    return;
+  }
+
+  const to = p.from + p.rows.length;
+  host.innerHTML =
+    `<button type="button" class="pg-prev"${p.at === 0 ? " disabled" : ""} aria-label="Previous page">←</button>` +
+    `<span class="pg-at">${num(p.from + 1)}–${num(to)} of ${num(p.total)}</span>` +
+    `<button type="button" class="pg-next"${p.at >= p.pages - 1 ? " disabled" : ""} aria-label="Next page">→</button>`;
+
+  const step = (by) => {
+    state.page[table] = p.at + by;
+    redraw();
+    // The table is now showing different rows some way up the page; without
+    // this you page forward and stay looking at the bottom of the last one.
+    el(table)?.scrollIntoView({ block: "nearest" });
+  };
+  host.querySelector(".pg-prev")?.addEventListener("click", () => step(-1));
+  host.querySelector(".pg-next")?.addEventListener("click", () => step(1));
+}
+
 function render(table, columns, rows, renderRow, redraw = draw) {
   const node = el(table);
 
   if (!rows.length) {
     node.innerHTML = `<tbody><tr><td class="none">Nothing matches.</td></tr></tbody>`;
+    pager(table, { pages: 1 }, redraw);
     return;
+  }
+
+  // Paginate only where the page asked for it, by putting a pager element in
+  // the markup. A six-row table needs no controls.
+  let shownRows = rows;
+  if (el(`${table}-pager`)) {
+    const p = pageOf(table, rows);
+    shownRows = p.rows;
+    pager(table, p, redraw);
   }
 
   // The control is a real <button> inside the <th>, not a click handler on the
@@ -368,7 +429,7 @@ function render(table, columns, rows, renderRow, redraw = draw) {
   const held =
     node.contains(document.activeElement) && document.activeElement.dataset.sort;
 
-  node.innerHTML = `<thead><tr>${head}</tr></thead><tbody>${rows.map((r, i) => renderRow(r, i)).join("")}</tbody>`;
+  node.innerHTML = `<thead><tr>${head}</tr></thead><tbody>${shownRows.map((r, i) => renderRow(r, i)).join("")}</tbody>`;
 
   if (held) node.querySelector(`button[data-sort="${CSS.escape(held)}"]`)?.focus();
 
@@ -378,6 +439,9 @@ function render(table, columns, rows, renderRow, redraw = draw) {
       const s = state.sort[table];
       s.dir = s.key === key ? -s.dir : -1;
       s.key = key;
+      // Re-sorting reorders the whole set, so page 12 of the old order means
+      // nothing in the new one.
+      state.page[table] = 0;
       redraw();
     });
   });
@@ -1226,11 +1290,6 @@ function taskState(state) {
   return "active";
 }
 
-// maxTasks caps what reaches the DOM. The current mission exports 1,414 tasks;
-// rendering all of them makes a wall nobody reads and a page that janks on
-// every poll. The count line says what was left out.
-const maxTasks = 200;
-
 // Mission tasks, when the mission exports any. The panel stays hidden rather
 // than showing an empty table on servers whose missions say nothing.
 function drawTasks(tableID, panelID, tasks, redraw = draw) {
@@ -1274,15 +1333,11 @@ function drawTasks(tableID, panelID, tasks, redraw = draw) {
       `<b>${num(tally.active)}</b> still running · <b>${num(earned)}</b> points banked`;
   }
 
-  const shown = rows.slice(0, maxTasks);
+  // The pager says where you are within the filtered set; this says how much
+  // the filter itself took out.
   const countEl = el("task-count");
   if (countEl) {
-    countEl.textContent =
-      rows.length > shown.length
-        ? `showing ${shown.length} of ${num(rows.length)}`
-        : rows.length === tally.all
-          ? ""
-          : `${num(rows.length)} of ${num(tally.all)}`;
+    countEl.textContent = rows.length === tally.all ? "" : `${num(rows.length)} of ${num(tally.all)} match`;
   }
 
   render(
@@ -1293,7 +1348,7 @@ function drawTasks(tableID, panelID, tasks, redraw = draw) {
       { label: "Pilot", key: "playerName" },
       { label: "Points", key: "points", num: true },
     ],
-    sortRows(shown, tableID),
+    sortRows(rows, tableID),
     (t) => {
       const s = taskState(t.state);
       return `<tr>
@@ -2293,6 +2348,12 @@ document.addEventListener("visibilitychange", () => {
   }
 });
 
+// Narrowing what a table shows invalidates where you were in it: page twelve
+// of everything is not page twelve of the four rows that matched.
+function resetPages() {
+  state.page = {};
+}
+
 function chips(container, attr, onPick) {
   // Not every control exists on every page: a mission recap is one finished
   // run, so it has no scope toggle to wire.
@@ -2302,6 +2363,7 @@ function chips(container, attr, onPick) {
     if (!btn) return;
     el(container).querySelectorAll("button").forEach((b) => b.classList.toggle("on", b === btn));
     onPick(btn.dataset[attr]);
+    resetPages();
     draw();
   });
 }
@@ -2333,6 +2395,7 @@ if (PAGE === "dashboard" || PAGE === "mission" || PAGE === "weapons" || PAGE ===
   if (el("task-pilot")) {
     el("task-pilot").addEventListener("change", (e) => {
       state.taskPilot = e.target.value;
+      resetPages();
       draw();
     });
   }
@@ -2349,6 +2412,7 @@ if (PAGE === "dashboard" || PAGE === "mission" || PAGE === "weapons" || PAGE ===
 
   el("q").addEventListener("input", (e) => {
     state.query = e.target.value.trim().toLowerCase();
+    resetPages();
     draw();
   });
 }
@@ -2356,6 +2420,7 @@ if (PAGE === "dashboard" || PAGE === "mission" || PAGE === "weapons" || PAGE ===
 if (PAGE === "player") {
   el("q").addEventListener("input", (e) => {
     state.query = e.target.value.trim().toLowerCase();
+    resetPages();
     drawPlayer();
   });
 }
@@ -2363,11 +2428,13 @@ if (PAGE === "player") {
 if (PAGE === "missions") {
   el("q").addEventListener("input", (e) => {
     state.query = e.target.value.trim().toLowerCase();
+    resetPages();
     draw();
   });
 
   el("pilot-filter").addEventListener("change", (e) => {
     state.pilotFilter = e.target.value;
+    resetPages();
     try {
       localStorage.setItem("overlord-pilot", state.pilotFilter);
     } catch {

--- a/web/app.js
+++ b/web/app.js
@@ -89,6 +89,7 @@ const state = {
     "p-weapons": { key: "shots", dir: -1 },
     "p-grades": { key: "missionTime", dir: -1 },
     tasks: { key: "points", dir: -1 },
+    recoveries: { key: "missionTime", dir: -1 },
     "player-tasks": { key: "points", dir: -1 },
   },
   // Which state the mission-task panel is narrowed to, and to whose tasks.
@@ -142,7 +143,8 @@ function dashQuery() {
 
   // Display names back every reference card and most tables, so they come
   // along wherever anything renders a unit or weapon by name.
-  const needNames = wants("weapons") || wants("records") || wants("killfeed") || wants("traps") || wants("log");
+  const needNames =
+    wants("weapons") || wants("records") || wants("killfeed") || wants("recoveries") || wants("log");
 
   return `{
   missions { id name theatre startedAt events duration }
@@ -158,7 +160,14 @@ function dashQuery() {
   ${wants("tug-blue") ? `killsByCoalition${p} { coalition kills teamkills }` : ""}
   ${wants("weapons") ? `weaponEffectiveness${p} { weaponType shots hits kills collisions hitsPerShot killsPerShot }` : ""}
   ${wants("pilots") ? `playerActivity${p} { playerID playerName kills takeoffs landings crashes ejections deaths }` : ""}
-  ${wants("traps") ? `landingGrades(first: 40${m ? ", " + m : ""}) { playerName unitType place grade missionTime }` : ""}
+  ${
+    wants("landings") || wants("recoveries")
+      ? `landingGrades(first: 500${m ? ", " + m : ""}) {
+    playerName playerID unitType place missionTime
+    mark score scored wire deviations
+  }`
+      : ""
+  }
   ${
     wants("records")
       ? `records${p} {
@@ -782,6 +791,120 @@ function highlightLine(h) {
   }
 }
 
+// --- landings ---------------------------------------------------------------
+
+// The Navy's grades, worst to best, with what each is worth and how it reads.
+// Ordered deliberately: a distribution is a shape, and the shape only means
+// anything if the axis runs one way.
+const LSO_MARKS = [
+  { mark: "WO", label: "Wave off", tone: "bad" },
+  { mark: "C", label: "Cut", tone: "bad" },
+  { mark: "B", label: "Bolter", tone: "mid" },
+  { mark: "---", label: "No grade", tone: "mid" },
+  { mark: "(OK)", label: "Fair", tone: "ok" },
+  { mark: "OK", label: "OK", tone: "ok" },
+  { mark: "_OK_", label: "Perfect", tone: "best" },
+];
+
+// A row of proportional bars. Used for both distributions, since they are the
+// same shape of question: how did these N things fall across these buckets.
+function distBar(buckets, total) {
+  if (!total) return "";
+  return (
+    `<div class="dist">` +
+    buckets
+      .filter((b) => b.n > 0)
+      .map(
+        (b) =>
+          `<span class="dist-seg dist-${b.tone || "mid"}" style="flex-grow:${b.n}"
+                 title="${esc(b.label)}: ${b.n}"><b>${b.n}</b></span>`
+      )
+      .join("") +
+    `</div>` +
+    `<ul class="dist-key">` +
+    buckets
+      .filter((b) => b.n > 0)
+      .map((b) => `<li><i class="dist-${b.tone || "mid"}"></i>${esc(b.label)} <b>${b.n}</b></li>`)
+      .join("") +
+    `</ul>`
+  );
+}
+
+// The landings panel: how the recoveries went, not which ones happened. The
+// list of individual passes is a page of its own, because a debrief wants the
+// shape and an argument about one trap wants the detail.
+function drawLandings(grades) {
+  const host = el("landings");
+  if (!host) return;
+
+  const passes = (grades || []).filter((g) => g.mark);
+  if (!passes.length) {
+    host.innerHTML = `<p class="none">No graded carrier recoveries yet.</p>`;
+    return;
+  }
+
+  const byMark = LSO_MARKS.map((m) => ({
+    ...m,
+    n: passes.filter((p) => p.mark === m.mark).length,
+  }));
+  // Anything DCS graded with a token we do not know still happened.
+  const unknown = passes.filter((p) => !p.scored).length;
+  if (unknown) byMark.push({ mark: "?", label: "Ungraded", tone: "mid", n: unknown });
+
+  const wires = [1, 2, 3, 4].map((w) => ({
+    label: `${w} wire`,
+    tone: w === 3 ? "best" : "mid",
+    n: passes.filter((p) => p.wire === w).length,
+  }));
+  const bolters = passes.filter((p) => p.wire === 0).length;
+  if (bolters) wires.push({ label: "Bolter", tone: "bad", n: bolters });
+
+  const scored = passes.filter((p) => p.scored);
+  const avg = scored.length ? scored.reduce((s, p) => s + p.score, 0) / scored.length : 0;
+
+  host.innerHTML =
+    `<div class="lso-head">
+       <div><dt>Traps</dt><dd>${num(passes.length)}</dd></div>
+       <div><dt>Average</dt><dd>${avg.toFixed(2)}<span class="lso-of"> / 4</span></dd></div>
+       <div><dt>Three wire</dt><dd>${Math.round((wires[2].n / passes.length) * 100)}<span class="lso-of">%</span></dd></div>
+     </div>` +
+    `<h3 class="dist-title">Grades</h3>${distBar(byMark, passes.length)}` +
+    `<h3 class="dist-title">Wire caught</h3>${distBar(wires, passes.length)}` +
+    (el("landings-more") ? "" : `<p class="dist-more"><a href="/landings">Every recovery, one by one →</a></p>`);
+}
+
+// Every pass, for the page that exists to show them.
+function drawRecoveries(grades) {
+  const rows = (grades || [])
+    .filter((g) => g.mark)
+    .filter((g) => matches([g.playerName, g.unitType, g.place, g.mark, ...(g.deviations || [])]));
+
+  render(
+    "recoveries",
+    [
+      { label: "Pilot", key: "playerName" },
+      { label: "Aircraft", key: "unitType" },
+      { label: "Grade", key: "mark" },
+      { label: "Score", key: "score", num: true },
+      { label: "Wire", key: "wire", num: true },
+      { label: "What the LSO saw" },
+      { label: "Time", key: "missionTime", num: true },
+    ],
+    sortRows(rows, "recoveries"),
+    (g) => `<tr>
+      <td class="name">${g.playerID ? pref(g.playerID, g.playerName) : esc(playerLabel(g.playerName))}</td>
+      <td>${ref("unit", g.unitType)}</td>
+      <td><span class="lso-mark lso-${esc(markTone(g.mark))}">${esc(g.mark)}</span></td>
+      <td class="num">${g.scored ? g.score.toFixed(1) : `<span class="zero">—</span>`}</td>
+      <td class="num">${g.wire ? g.wire : `<span class="zero">bolter</span>`}</td>
+      <td class="lso-devs">${g.deviations.length ? esc(g.deviations.join("; ")) : `<span class="zero">clean pass</span>`}</td>
+      <td class="num">${clock(g.missionTime)}</td>
+    </tr>`
+  );
+}
+
+const markTone = (mark) => LSO_MARKS.find((m) => m.mark === mark)?.tone || "mid";
+
 // The index of recorded runs. Newest first, each linking to its own recap.
 //
 // Quiet runs are dropped: a mission that recorded four events is a server
@@ -885,7 +1008,8 @@ function draw() {
   if (wants("missions")) drawMissions(d.missionIndex || []);
   if (wants("weapons")) drawWeapons(d.weaponEffectiveness || []);
   if (wants("pilots")) drawPilots(d.playerActivity || []);
-  if (wants("traps")) drawTraps(d.landingGrades || []);
+  if (wants("landings")) drawLandings(d.landingGrades || []);
+  if (wants("recoveries")) drawRecoveries(d.landingGrades || []);
   if (wants("log")) drawLog(state.log);
   if (wants("records")) drawRecords(d.records);
   if (wants("tasks")) drawTasks("tasks", "p-tasks", d.missionTasks);
@@ -2387,7 +2511,7 @@ chips("scope", "scope", (v) => {
   }
 }
 
-if (PAGE === "dashboard" || PAGE === "mission" || PAGE === "weapons" || PAGE === "log") {
+if (["dashboard", "mission", "weapons", "log", "landings"].includes(PAGE)) {
   chips("weapon-class", "class", (v) => (state.weaponClass = v));
 
   // Both narrow what is already loaded, so they redraw rather than refetch.
@@ -2425,7 +2549,7 @@ if (PAGE === "player") {
   });
 }
 
-if (PAGE === "missions") {
+if (PAGE === "missions" || PAGE === "landings") {
   el("q").addEventListener("input", (e) => {
     state.query = e.target.value.trim().toLowerCase();
     resetPages();

--- a/web/embed.go
+++ b/web/embed.go
@@ -18,7 +18,7 @@ import (
 // browser will keep serving the previous version, which looks exactly like a
 // caching problem and is not one.
 //
-//go:embed index.html player.html mission.html missions.html weapons.html log.html app.css app.js
+//go:embed index.html player.html mission.html missions.html weapons.html landings.html log.html app.css app.js
 var files embed.FS
 
 // FS returns the dashboard's static files.

--- a/web/index.html
+++ b/web/index.html
@@ -42,6 +42,7 @@
       <a href="/" data-nav="dashboard">Debrief</a>
       <a href="/missions" data-nav="missions">Missions</a>
       <a href="/weapons" data-nav="weapons">Weapons</a>
+      <a href="/landings" data-nav="landings">Landings</a>
       <a href="/log" data-nav="log">Log</a>
     </nav>
 
@@ -119,10 +120,13 @@
       <div id="opposition" class="opposition"></div>
     </section>
 
-    <section class="card-panel" id="p-traps">
+    <!-- How the recoveries went, not which ones happened. One trap is an
+         argument; the shape of thirty of them is a debrief. The individual
+         passes are a page of their own. -->
+    <section class="card-panel" id="p-landings">
       <div class="phead"><h2>Landings</h2></div>
-      <p class="note">Graded by DCS. Carrier traps include the wire and deviations.</p>
-      <div class="tw"><table id="traps" class="grid"></table></div>
+      <p class="note">Carrier recoveries as the LSO graded them.</p>
+      <div id="landings"></div>
     </section>
   </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -142,7 +142,8 @@
     </div>
     <p class="note">Set and scored by the mission itself, straight from its own scripting.</p>
     <p class="tally" id="task-tally"></p>
-    <div class="tw tw-tall"><table id="tasks" class="grid"></table></div>
+    <div class="tw"><table id="tasks" class="grid"></table></div>
+    <div class="pager" id="tasks-pager"></div>
   </section>
 
 </main>

--- a/web/landings.html
+++ b/web/landings.html
@@ -6,7 +6,7 @@
 <!-- Declared before any CSS arrives so the browser paints the canvas in a
      sane colour from the first frame. app.js narrows it to the chosen theme. -->
 <meta name="color-scheme" content="light dark">
-<title>Weapons — Overlord</title>
+<title>Landings — Overlord</title>
 <link rel="stylesheet" href="/app.css">
 <script>
   // Resolve the theme before first paint. app.css has no prefers-color-scheme
@@ -20,7 +20,7 @@
   })();
 </script>
 </head>
-<body data-page="weapons">
+<body data-page="landings">
 
 <!-- The same header on every section. The four-figure readout that used to sit
      here is gone: mission time was already in the hero below it, and the other
@@ -47,7 +47,7 @@
         <button type="button" data-scope="all">All time</button>
       </div>
       <label class="vh" for="q">Filter everything</label>
-      <input type="search" id="q" placeholder="Filter weapons…" autocomplete="off">
+      <input type="search" id="q" placeholder="Filter pilots, deviations…" autocomplete="off">
       <button id="theme" type="button">Theme</button>
       <label class="toggle"><input type="checkbox" id="live" checked> Live</label>
       <span id="link" class="status" role="status">Connecting</span>
@@ -57,30 +57,24 @@
 
 <main>
 
-  <section class="card-panel" id="p-weapons">
-    <div class="phead">
-      <h2>Weapons</h2>
-      <div class="chips" id="weapon-class" role="group" aria-label="Filter by weapon type">
-        <button type="button" data-class="all" class="on">All</button>
-        <button type="button" data-class="ordnance">Missiles &amp; bombs</button>
-        <button type="button" data-class="gun">Guns</button>
-        <button type="button" data-class="collision">Collisions</button>
-      </div>
-    </div>
-    <p class="note">
-      Hits per shot is a ratio and can exceed 1 legitimately — DCS reports one shot per launch but one hit per
-      object damaged, so cluster and splash weapons register several. Guns report hits and no shots, so they
-      have no ratio. Rows named after an aircraft are collisions, where DCS names the aircraft as the weapon;
-      those are counted apart from hits and kills so they do not flatter any weapon's figures.
-    </p>
-    <div class="tw"><table id="weapons" class="grid"></table></div>
-    <div class="pager" id="weapons-pager"></div>
+  <section class="card-panel" id="p-landings">
+    <div class="phead"><h2>How the recoveries went</h2></div>
+    <div id="landings"></div>
+    <span id="landings-more" hidden></span>
   </section>
 
-  <section class="card-panel" id="p-collateral">
-    <div class="phead"><h2>Collateral damage</h2></div>
-    <p class="note">What the ordnance above caught that was never a threat.</p>
-    <div id="collateral"></div>
+  <section class="card-panel" id="p-recoveries">
+    <div class="phead">
+      <h2>Every recovery</h2>
+      <span class="count" id="recoveries-count"></span>
+    </div>
+    <p class="note">
+      One row per pass. The grade, the wire and the LSO's remarks come from a single line of
+      shorthand DCS writes — <code>LSO: GRADE:C : LNFIW  WIRE# 2</code> — read out into parts here.
+      Score is the Navy's four-point scale: a perfect pass is 4, a cut pass 1.
+    </p>
+    <div class="tw"><table id="recoveries" class="grid"></table></div>
+    <div class="pager" id="recoveries-pager"></div>
   </section>
 
 </main>

--- a/web/log.html
+++ b/web/log.html
@@ -74,7 +74,8 @@
       </div>
     </div>
     <p class="note">Straight from DCS, newest first. The raw record behind every other number on the site.</p>
-    <div class="tw tw-tall"><table id="log" class="grid"></table></div>
+    <div class="tw"><table id="log" class="grid"></table></div>
+    <div class="pager" id="log-pager"></div>
   </section>
 
 </main>

--- a/web/log.html
+++ b/web/log.html
@@ -37,6 +37,7 @@
       <a href="/" data-nav="dashboard">Debrief</a>
       <a href="/missions" data-nav="missions">Missions</a>
       <a href="/weapons" data-nav="weapons">Weapons</a>
+      <a href="/landings" data-nav="landings">Landings</a>
       <a href="/log" data-nav="log">Log</a>
     </nav>
 

--- a/web/mission.html
+++ b/web/mission.html
@@ -38,6 +38,7 @@
       <a href="/" data-nav="dashboard">Debrief</a>
       <a href="/missions" data-nav="missions">Missions</a>
       <a href="/weapons" data-nav="weapons">Weapons</a>
+      <a href="/landings" data-nav="landings">Landings</a>
       <a href="/log" data-nav="log">Log</a>
     </nav>
 
@@ -132,10 +133,13 @@
       <div id="opposition" class="opposition"></div>
     </section>
 
-    <section class="card-panel" id="p-traps">
+    <!-- How the recoveries went, not which ones happened. One trap is an
+         argument; the shape of thirty of them is a debrief. The individual
+         passes are a page of their own. -->
+    <section class="card-panel" id="p-landings">
       <div class="phead"><h2>Landings</h2></div>
-      <p class="note">Graded by DCS. Carrier traps include the wire and deviations.</p>
-      <div class="tw"><table id="traps" class="grid"></table></div>
+      <p class="note">Carrier recoveries as the LSO graded them.</p>
+      <div id="landings"></div>
     </section>
   </div>
 

--- a/web/mission.html
+++ b/web/mission.html
@@ -119,6 +119,7 @@
       those are counted apart from hits and kills so they do not flatter any weapon's figures.
     </p>
     <div class="tw"><table id="weapons" class="grid"></table></div>
+    <div class="pager" id="weapons-pager"></div>
   </section>
 
   <div class="split">
@@ -154,7 +155,8 @@
     </div>
     <p class="note">Set and scored by the mission itself, straight from its own scripting.</p>
     <p class="tally" id="task-tally"></p>
-    <div class="tw tw-tall"><table id="tasks" class="grid"></table></div>
+    <div class="tw"><table id="tasks" class="grid"></table></div>
+    <div class="pager" id="tasks-pager"></div>
   </section>
 
   <section class="card-panel" id="p-collateral">
@@ -179,7 +181,8 @@
         <button type="button" data-side="red" class="side-red">Red</button>
       </div>
     </div>
-    <div class="tw tw-tall"><table id="log" class="grid"></table></div>
+    <div class="tw"><table id="log" class="grid"></table></div>
+    <div class="pager" id="log-pager"></div>
   </section>
 
 </main>

--- a/web/missions.html
+++ b/web/missions.html
@@ -37,6 +37,7 @@
       <a href="/" data-nav="dashboard">Debrief</a>
       <a href="/missions" data-nav="missions">Missions</a>
       <a href="/weapons" data-nav="weapons">Weapons</a>
+      <a href="/landings" data-nav="landings">Landings</a>
       <a href="/log" data-nav="log">Log</a>
     </nav>
 

--- a/web/player.html
+++ b/web/player.html
@@ -39,6 +39,7 @@
       <a href="/" data-nav="dashboard">Debrief</a>
       <a href="/missions" data-nav="missions">Missions</a>
       <a href="/weapons" data-nav="weapons">Weapons</a>
+      <a href="/landings" data-nav="landings">Landings</a>
       <a href="/log" data-nav="log">Log</a>
     </nav>
 

--- a/web/player.html
+++ b/web/player.html
@@ -129,7 +129,8 @@
 
     <section class="card-panel">
       <div class="phead"><h2>Weapons</h2></div>
-      <div class="tw tw-tall"><table id="p-weapons" class="grid"></table></div>
+      <div class="tw"><table id="p-weapons" class="grid"></table></div>
+    <div class="pager" id="p-weapons-pager"></div>
     </section>
   </div>
 

--- a/web/weapons.html
+++ b/web/weapons.html
@@ -73,6 +73,7 @@
       those are counted apart from hits and kills so they do not flatter any weapon's figures.
     </p>
     <div class="tw"><table id="weapons" class="grid"></table></div>
+    <div class="pager" id="weapons-pager"></div>
   </section>
 
   <section class="card-panel" id="p-collateral">


### PR DESCRIPTION
DCS reports a carrier trap as a single line of Landing Signal Officer shorthand:

```
LSO: GRADE:C : LNFIW  WIRE# 2
```

Shown raw — which is what the Landings table did — that is unreadable unless you have flown the pattern, and unusable for anything but reading. Parsed, it becomes:

```
C   1.0   wire 2   not enough line-up correction in the wires
```

## The debrief gets a shape, not a list

```
Landings
TRAPS  32     AVERAGE  2.16 / 4     THREE WIRE  19%

GRADES     ▉Wave off 1 ▉▉▉▉▉▉Cut 12 ▉▉▉▉▉No grade 9 ▉OK 1 ▉▉▉▉▉Perfect 9
WIRE       ▉▉1 wire 5 ▉▉▉▉2 wire 9 ▉▉▉3 wire 6 ▉▉▉▉▉4 wire 11 ▉Bolter 1
                                       Every recovery, one by one →
```

One trap is an argument; the shape of thirty is a debrief. **`/landings`** holds the individual passes — pilot, aircraft, grade, score, wire, and what the LSO actually saw — sortable and paginated.

## Parsed server-side, on purpose

It is a property of the recording, not of one page: the chart, the table and anything later should all agree about what a pass was worth. Scores follow the standard USN four-point scale so an average means what it means in a ready room (`_OK_` 4, `OK` 3, `(OK)` 2.5, `---`/`B` 2, `C` 1, `WO` 0). A grade we do not recognise keeps its name, is flagged `scored: false`, and is **excluded from the average rather than counted as a zero** — otherwise unknown tokens would silently drag every pilot down.

## Two mistakes worth recording

Both caught by tests written against strings taken verbatim from the database:

1. The first parser sliced by the *length* of the grade match rather than where it *ended*, leaving `ADE:C :` in the remarks. Indices, not lengths.
2. It read `LNFIW` as one unknown code. The LSO runs them together — that is `LNF` then `IW`. Codes now match longest-first, so `LOAR` stays "low at the ramp" rather than becoming `LO` + `AR`.

## Verified

32 recorded traps, all on the Stennis. Grades C×12, `_OK_`×9, `---`×9, OK×1, WO×1; wires 4×11, 2×9, 3×6, 1×5 and one bolter; average 2.16. Debrief shows the chart with the through-link and no table; `/landings` lists all 32 with display names, colour-coded grades, and clean passes reading "clean pass". Nav carries the new section on every page. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)