### PR TITLE
Add an airframes page with a head-to-head matrix

### DIFF
--- a/controllers/airframes.go
+++ b/controllers/airframes.go
@@ -1,0 +1,124 @@
+package controllers
+
+import (
+	"github.com/MartinHell/overlord/initializers"
+	"github.com/MartinHell/overlord/logs"
+	"github.com/MartinHell/overlord/models"
+)
+
+// Airframes: every type that has flown, side by side.
+//
+// The reference card already answers "how did the Hornet do"; this answers
+// "how did the Hornet do compared with everything else", which is the question
+// the weapons table has been answering for stores all along.
+//
+// Restricted to types seen as an initiator of something, which is what keeps
+// the scenery out without a second rule: a tree never took off or fired.
+
+// GetAirframes totals one row per aircraft or vehicle type.
+func GetAirframes(missionID *uint) ([]*models.AirframeStats, error) {
+	var rows []models.AirframeStats
+
+	// Collisions are held apart from kills, as they are on the weapons page and
+	// for the same reason. DCS names the airframe as the weapon when an
+	// aircraft goes into something, so counting those as kills made the A-50 --
+	// an airborne radar with no weapons at all -- the third deadliest aircraft
+	// on the server with 135 of them.
+	//
+	// Same test as isCollision, written against this query's aliases.
+	const rammed = `(weapons.type = units.type AND weapons.type NOT LIKE 'weapons.%')`
+
+	// One pass for everything this type did.
+	if err := initializers.DB.Model(&models.Event{}).
+		Scopes(scopeMission(missionID)).
+		Select(`units.type AS unit_type,
+			SUM(CASE WHEN events.event IN ('takeoff','runway_takeoff') THEN 1 ELSE 0 END) AS sorties,
+			SUM(CASE WHEN events.event IN ('land','runway_touch') THEN 1 ELSE 0 END) AS landings,
+			SUM(CASE WHEN events.event = 'shot' THEN 1 ELSE 0 END) AS shots,
+			SUM(CASE WHEN events.event = 'hit' AND `+notScenery+`
+				AND NOT `+rammed+` THEN 1 ELSE 0 END) AS hits,
+			SUM(CASE WHEN events.event = 'kill' AND `+notScenery+`
+				AND NOT `+rammed+` THEN 1 ELSE 0 END) AS kills,
+			SUM(CASE WHEN events.event IN ('hit','kill') AND `+rammed+` THEN 1 ELSE 0 END) AS collisions,
+			SUM(CASE WHEN events.event IN ('crash','dead','unit_lost','pilot_dead') THEN 1 ELSE 0 END) AS losses,
+			SUM(CASE WHEN events.event = 'ejection' THEN 1 ELSE 0 END) AS ejections`).
+		Joins("JOIN units ON units.unit_id = events.initiator_unit_id").
+		Joins("LEFT JOIN targets ON targets.target_id = events.target_id").
+		Joins("LEFT JOIN weapons ON weapons.weapon_id = events.weapon_id").
+		Where("events.initiator_kind = ?", models.ObjectKindUnit).
+		Group("units.type").
+		Scan(&rows).Error; err != nil {
+		logs.Sugar.Errorf("Failed to aggregate airframes: %v", err)
+		return nil, err
+	}
+
+	// How often each was on the receiving end. Counted separately because it
+	// keys on the target rather than the initiator, and a type can be shot
+	// down having never fired a shot itself.
+	var losses []struct {
+		UnitType    string
+		TimesKilled int
+	}
+	if err := initializers.DB.Model(&models.Event{}).
+		Scopes(scopeMission(missionID)).
+		Select("units.type AS unit_type, COUNT(*) AS times_killed").
+		Joins("JOIN targets ON targets.target_id = events.target_id").
+		Joins("JOIN units ON units.unit_id = targets.unit_id").
+		Where("events.event = ? AND targets.kind = ?", "kill", models.ObjectKindUnit).
+		Group("units.type").
+		Scan(&losses).Error; err != nil {
+		logs.Sugar.Errorf("Failed to count airframe losses: %v", err)
+		return nil, err
+	}
+
+	byType := map[string]*models.AirframeStats{}
+	result := make([]*models.AirframeStats, 0, len(rows))
+	for i := range rows {
+		byType[rows[i].UnitType] = &rows[i]
+		result = append(result, &rows[i])
+	}
+	for _, l := range losses {
+		if a := byType[l.UnitType]; a != nil {
+			a.TimesKilled = l.TimesKilled
+			continue
+		}
+		// Shot down without ever having done anything itself. It still flew.
+		a := &models.AirframeStats{UnitType: l.UnitType, TimesKilled: l.TimesKilled}
+		byType[l.UnitType] = a
+		result = append(result, a)
+	}
+
+	return result, nil
+}
+
+// GetAirframeMatchups is the kill matrix: what each type shot down, and what
+// shot it down, across every pilot on the server.
+//
+// The player page has this per pilot. Server-wide it answers a different
+// question -- which airframe actually beats which -- and it is the closest
+// thing the data has to a head-to-head record between machines.
+func GetAirframeMatchups(missionID *uint) ([]*models.Matchup, error) {
+	var rows []models.Matchup
+
+	if err := initializers.DB.Model(&models.Event{}).
+		Scopes(scopeMission(missionID)).
+		Select("units.type AS unit_type, tunits.type AS target_type, COUNT(*) AS kills").
+		Joins("JOIN targets ON targets.target_id = events.target_id").
+		Joins("JOIN units AS tunits ON tunits.unit_id = targets.unit_id").
+		Joins("JOIN units ON units.unit_id = events.initiator_unit_id").
+		Where("events.event = ? AND targets.kind = ? AND events.initiator_kind = ?",
+			"kill", models.ObjectKindUnit, models.ObjectKindUnit).
+		Group("units.type, tunits.type").
+		Order("kills DESC").
+		Scan(&rows).Error; err != nil {
+		logs.Sugar.Errorf("Failed to aggregate airframe matchups: %v", err)
+		return nil, err
+	}
+
+	result := make([]*models.Matchup, 0, len(rows))
+	for i := range rows {
+		result = append(result, &rows[i])
+	}
+
+	return result, nil
+}

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -67,6 +67,9 @@ models:
   Sortie:
     model:
       - github.com/MartinHell/overlord/models.Sortie
+  AirframeStats:
+    model:
+      - github.com/MartinHell/overlord/models.AirframeStats
   MissionEntry:
     model:
       - github.com/MartinHell/overlord/models.MissionEntry

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -166,6 +166,16 @@ func (r *queryResolver) MissionIndex(ctx context.Context) ([]*models.MissionEntr
 	return controllers.GetMissionIndex()
 }
 
+// Airframes is the resolver for the airframes field.
+func (r *queryResolver) Airframes(ctx context.Context, missionID *string) ([]*models.AirframeStats, error) {
+	return controllers.GetAirframes(parseOptionalID(missionID))
+}
+
+// AirframeMatchups is the resolver for the airframeMatchups field.
+func (r *queryResolver) AirframeMatchups(ctx context.Context, missionID *string) ([]*models.Matchup, error) {
+	return controllers.GetAirframeMatchups(parseOptionalID(missionID))
+}
+
 // KillsByCoalition returns the kill tally for every coalition at once.
 func (r *queryResolver) KillsByCoalition(ctx context.Context, missionID *string) ([]*models.CoalitionKills, error) {
 	return controllers.GetKillsByCoalition(parseOptionalID(missionID))

--- a/graph/schema.graphql
+++ b/graph/schema.graphql
@@ -351,6 +351,35 @@ type PlayerAircraftStats {
     killsPerShot: Float!
 }
 
+"""
+One aircraft or vehicle type's whole record, summed across every pilot.
+
+The same shape as PlayerAircraftStats, but for the page that puts every type
+beside every other rather than one pilot's use of it.
+"""
+type AirframeStats {
+    unitType: String!
+    sorties: Int!
+    landings: Int!
+    shots: Int!
+    "Excludes scenery."
+    hits: Int!
+    "Excludes scenery and collisions."
+    kills: Int!
+    "Hits and kills where this airframe was flown into something. See WeaponEffectiveness.collisions."
+    collisions: Int!
+    "Anything that ended one of these while it was the initiator: crash, death, ejection."
+    losses: Int!
+    ejections: Int!
+    "How often one was destroyed by somebody else, which the counts above cannot see."
+    timesKilled: Int!
+    "Kills over timesKilled. Falls back to the kill count when none were lost."
+    killDeathRatio: Float!
+    "A ratio, not a percentage — see WeaponEffectiveness.hitsPerShot."
+    hitsPerShot: Float!
+    killsPerShot: Float!
+}
+
 "A kill tally for one airframe against one other type."
 type Matchup {
     "The airframe that did the killing."
@@ -673,6 +702,10 @@ type Query {
     missions: [Mission!]!
     "Every recorded run with the detail the index page shows. Heavier than missions; ask for it only there."
     missionIndex: [MissionEntry!]!
+    "Every airframe and vehicle type that has flown, side by side."
+    airframes(missionID: ID): [AirframeStats!]!
+    "The kill matrix between types, across every pilot: which airframe beats which."
+    airframeMatchups(missionID: ID): [Matchup!]!
     "Kill tally per coalition, covering both sides. Omit missionID for all of recorded history."
     killsByCoalition(missionID: ID): [CoalitionKills!]!
     "Shots, hits, kills, accuracy and Pk per weapon type."

--- a/models/summary.go
+++ b/models/summary.go
@@ -475,3 +475,49 @@ type WeaponProfileView struct {
 	// Carriers are the airframes seen firing it, busiest first.
 	Carriers []*UnitShotBreakdown
 }
+
+// AirframeStats is one aircraft or vehicle type's whole record, for the page
+// that puts every type beside every other. The same shape as
+// PlayerAircraftStats, but summed across every pilot rather than one.
+type AirframeStats struct {
+	UnitType  string
+	Sorties   int
+	Landings  int
+	Shots     int
+	Hits      int
+	Kills     int
+	// Collisions are hits and kills where this airframe was flown into
+	// something, which DCS reports as the airframe being the weapon. Held out
+	// of Kills for the same reason as on WeaponEffectiveness.
+	Collisions int
+	Losses     int
+	Ejections  int
+	// TimesKilled is how often one of these was destroyed by somebody else,
+	// which the initiator-side counts above cannot see.
+	TimesKilled int
+}
+
+// KillDeathRatio counts a loss as anything that ended the airframe. No losses
+// returns the kill count rather than dividing by zero.
+func (a *AirframeStats) KillDeathRatio() float64 {
+	if a.TimesKilled == 0 {
+		return float64(a.Kills)
+	}
+	return float64(a.Kills) / float64(a.TimesKilled)
+}
+
+// HitsPerShot carries the same caveat as everywhere else: a ratio that
+// legitimately exceeds 1, not a percentage.
+func (a *AirframeStats) HitsPerShot() float64 {
+	if a.Shots == 0 {
+		return 0
+	}
+	return float64(a.Hits) / float64(a.Shots)
+}
+
+func (a *AirframeStats) KillsPerShot() float64 {
+	if a.Shots == 0 {
+		return 0
+	}
+	return float64(a.Kills) / float64(a.Shots)
+}

--- a/routers/graphql.go
+++ b/routers/graphql.go
@@ -104,6 +104,7 @@ func GraphQLHandler() {
 	// bookmarked and opened in a tab, rather than a panel someone has to scroll
 	// past on the way to the one they wanted.
 	mux.HandleFunc("/missions", servePage("missions.html"))
+	mux.HandleFunc("/airframes", servePage("airframes.html"))
 	mux.HandleFunc("/weapons", servePage("weapons.html"))
 	mux.HandleFunc("/landings", servePage("landings.html"))
 	mux.HandleFunc("/log", servePage("log.html"))

--- a/web/airframes.html
+++ b/web/airframes.html
@@ -6,7 +6,7 @@
 <!-- Declared before any CSS arrives so the browser paints the canvas in a
      sane colour from the first frame. app.js narrows it to the chosen theme. -->
 <meta name="color-scheme" content="light dark">
-<title>Event log — Overlord</title>
+<title>Airframes — Overlord</title>
 <link rel="stylesheet" href="/app.css">
 <script>
   // Resolve the theme before first paint. app.css has no prefers-color-scheme
@@ -20,7 +20,7 @@
   })();
 </script>
 </head>
-<body data-page="log">
+<body data-page="airframes">
 
 <!-- The same header on every section. The four-figure readout that used to sit
      here is gone: mission time was already in the hero below it, and the other
@@ -48,7 +48,7 @@
         <button type="button" data-scope="all">All time</button>
       </div>
       <label class="vh" for="q">Filter everything</label>
-      <input type="search" id="q" placeholder="Filter events…" autocomplete="off">
+      <input type="search" id="q" placeholder="Filter airframes…" autocomplete="off">
       <button id="theme" type="button">Theme</button>
       <label class="toggle"><input type="checkbox" id="live" checked> Live</label>
       <span id="link" class="status" role="status">Connecting</span>
@@ -58,26 +58,28 @@
 
 <main>
 
-  <section class="card-panel" id="p-log">
+  <section class="card-panel" id="p-airframes">
     <div class="phead">
-      <h2>Events</h2>
-      <div class="chips" id="log-filter" role="group" aria-label="Filter the event log">
-        <button type="button" data-ev="all" class="on">All</button>
-        <button type="button" data-ev="kill">Kills</button>
-        <button type="button" data-ev="hit">Hits</button>
-        <button type="button" data-ev="shot">Shots</button>
-        <button type="button" data-ev="losses">Losses</button>
-        <button type="button" data-ev="sortie">Sorties</button>
-      </div>
-      <div class="chips" id="log-side" role="group" aria-label="Filter by coalition">
-        <button type="button" data-side="all" class="on">Both sides</button>
-        <button type="button" data-side="blue" class="side-blue">Blue</button>
-        <button type="button" data-side="red" class="side-red">Red</button>
-      </div>
+      <h2>Airframes</h2>
+      <span class="count" id="airframes-count"></span>
     </div>
-    <p class="note">Straight from DCS, newest first. The raw record behind every other number on the site.</p>
-    <div class="tw"><table id="log" class="grid"></table></div>
-    <div class="pager" id="log-pager"></div>
+    <p class="note">
+      Every aircraft and vehicle type that has flown or fired, summed across every pilot. Collisions are
+      counted apart from kills — DCS names the airframe as the weapon when one is flown into something,
+      which otherwise made an airborne radar the third deadliest aircraft on the server.
+      Click a name for its reference card.
+    </p>
+    <div class="tw"><table id="airframes" class="grid"></table></div>
+    <div class="pager" id="airframes-pager"></div>
+  </section>
+
+  <section class="card-panel" id="p-af-matchups">
+    <div class="phead"><h2>Head to head</h2></div>
+    <p class="note">
+      Which airframe actually beats which, across every pilot on the server. Rows are the killer,
+      columns the killed. Darker is more.
+    </p>
+    <div id="af-matchups"></div>
   </section>
 
 </main>

--- a/web/app.js
+++ b/web/app.js
@@ -90,6 +90,7 @@ const state = {
     "p-grades": { key: "missionTime", dir: -1 },
     tasks: { key: "points", dir: -1 },
     recoveries: { key: "missionTime", dir: -1 },
+    airframes: { key: "kills", dir: -1 },
     "player-tasks": { key: "points", dir: -1 },
   },
   // Which state the mission-task panel is narrowed to, and to whose tasks.
@@ -144,7 +145,13 @@ function dashQuery() {
   // Display names back every reference card and most tables, so they come
   // along wherever anything renders a unit or weapon by name.
   const needNames =
-    wants("weapons") || wants("records") || wants("killfeed") || wants("recoveries") || wants("log");
+    wants("weapons") ||
+    wants("records") ||
+    wants("killfeed") ||
+    wants("recoveries") ||
+    wants("airframes") ||
+    wants("af-matchups") ||
+    wants("log");
 
   return `{
   missions { id name theatre startedAt events duration }
@@ -158,6 +165,8 @@ function dashQuery() {
       : ""
   }
   ${wants("tug-blue") ? `killsByCoalition${p} { coalition kills teamkills }` : ""}
+  ${wants("airframes") ? `airframes${p} { unitType sorties landings shots hits kills collisions losses ejections timesKilled killDeathRatio hitsPerShot killsPerShot }` : ""}
+  ${wants("af-matchups") ? `airframeMatchups${p} { unitType targetType kills }` : ""}
   ${wants("weapons") ? `weaponEffectiveness${p} { weaponType shots hits kills collisions hitsPerShot killsPerShot }` : ""}
   ${wants("pilots") ? `playerActivity${p} { playerID playerName kills takeoffs landings crashes ejections deaths }` : ""}
   ${
@@ -791,6 +800,49 @@ function highlightLine(h) {
   }
 }
 
+// --- airframes ---------------------------------------------------------------
+
+// Every type side by side. The reference card answers "how did the Hornet do";
+// this answers "compared with what else", which is what the weapons table has
+// been doing for stores all along.
+function drawAirframes(rows) {
+  const list = (rows || []).filter((a) => matches(unitHay(a.unitType)));
+
+  const countEl = el("airframes-count");
+  if (countEl) countEl.textContent = `${num(list.length)} types`;
+
+  // The column only earns its width when something in view has rammed
+  // something, exactly as on the weapons table.
+  const anyCollisions = list.some((a) => a.collisions > 0);
+
+  render(
+    "airframes",
+    [
+      { label: "Type", key: "unitType" },
+      { label: "Sorties", key: "sorties", num: true },
+      { label: "Shots", key: "shots", num: true },
+      { label: "Hits", key: "hits", num: true },
+      { label: "Kills", key: "kills", num: true },
+      ...(anyCollisions ? [{ label: "Collisions", key: "collisions", num: true }] : []),
+      { label: "Lost", key: "timesKilled", num: true },
+      { label: "K/D", key: "killDeathRatio", num: true },
+      { label: "Hits / shot", key: "hitsPerShot", num: true },
+    ],
+    sortRows(list, "airframes"),
+    (a) => `<tr>
+      <td class="name">${ref("unit", a.unitType)}</td>
+      <td class="num">${num(a.sorties)}</td>
+      <td class="num">${num(a.shots)}</td>
+      <td class="num">${num(a.hits)}</td>
+      <td class="num">${num(a.kills)}</td>
+      ${anyCollisions ? `<td class="num">${num(a.collisions)}</td>` : ""}
+      <td class="num">${num(a.timesKilled)}</td>
+      <td class="num">${a.kills || a.timesKilled ? ratio(a.killDeathRatio) : `<span class="zero">—</span>`}</td>
+      <td class="num">${a.shots ? ratio(a.hitsPerShot) : `<span class="zero">—</span>`}</td>
+    </tr>`
+  );
+}
+
 // --- landings ---------------------------------------------------------------
 
 // The Navy's grades, worst to best, with what each is worth and how it reads.
@@ -1008,6 +1060,15 @@ function draw() {
   if (wants("missions")) drawMissions(d.missionIndex || []);
   if (wants("weapons")) drawWeapons(d.weaponEffectiveness || []);
   if (wants("pilots")) drawPilots(d.playerActivity || []);
+  if (wants("airframes")) drawAirframes(d.airframes || []);
+  if (wants("af-matchups")) {
+    el("af-matchups").innerHTML = heatmap(
+      (d.airframeMatchups || []).filter(
+        (m) => matches([...unitHay(m.unitType), ...unitHay(m.targetType)])
+      ),
+      { rowNoun: "airframes", colNoun: "target types" }
+    );
+  }
   if (wants("landings")) drawLandings(d.landingGrades || []);
   if (wants("recoveries")) drawRecoveries(d.landingGrades || []);
   if (wants("log")) drawLog(state.log);
@@ -2511,7 +2572,7 @@ chips("scope", "scope", (v) => {
   }
 }
 
-if (["dashboard", "mission", "weapons", "log", "landings"].includes(PAGE)) {
+if (["dashboard", "mission", "weapons", "log", "landings", "airframes"].includes(PAGE)) {
   chips("weapon-class", "class", (v) => (state.weaponClass = v));
 
   // Both narrow what is already loaded, so they redraw rather than refetch.
@@ -2549,7 +2610,7 @@ if (PAGE === "player") {
   });
 }
 
-if (PAGE === "missions" || PAGE === "landings") {
+if (["missions", "landings", "airframes"].includes(PAGE)) {
   el("q").addEventListener("input", (e) => {
     state.query = e.target.value.trim().toLowerCase();
     resetPages();

--- a/web/embed.go
+++ b/web/embed.go
@@ -18,7 +18,7 @@ import (
 // browser will keep serving the previous version, which looks exactly like a
 // caching problem and is not one.
 //
-//go:embed index.html player.html mission.html missions.html weapons.html landings.html log.html app.css app.js
+//go:embed index.html player.html mission.html missions.html airframes.html weapons.html landings.html log.html app.css app.js
 var files embed.FS
 
 // FS returns the dashboard's static files.

--- a/web/index.html
+++ b/web/index.html
@@ -41,6 +41,7 @@
     <nav class="nav" aria-label="Sections">
       <a href="/" data-nav="dashboard">Debrief</a>
       <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/airframes" data-nav="airframes">Airframes</a>
       <a href="/weapons" data-nav="weapons">Weapons</a>
       <a href="/landings" data-nav="landings">Landings</a>
       <a href="/log" data-nav="log">Log</a>

--- a/web/landings.html
+++ b/web/landings.html
@@ -36,6 +36,7 @@
     <nav class="nav" aria-label="Sections">
       <a href="/" data-nav="dashboard">Debrief</a>
       <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/airframes" data-nav="airframes">Airframes</a>
       <a href="/weapons" data-nav="weapons">Weapons</a>
       <a href="/landings" data-nav="landings">Landings</a>
       <a href="/log" data-nav="log">Log</a>

--- a/web/mission.html
+++ b/web/mission.html
@@ -37,6 +37,7 @@
     <nav class="nav" aria-label="Sections">
       <a href="/" data-nav="dashboard">Debrief</a>
       <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/airframes" data-nav="airframes">Airframes</a>
       <a href="/weapons" data-nav="weapons">Weapons</a>
       <a href="/landings" data-nav="landings">Landings</a>
       <a href="/log" data-nav="log">Log</a>

--- a/web/missions.html
+++ b/web/missions.html
@@ -36,6 +36,7 @@
     <nav class="nav" aria-label="Sections">
       <a href="/" data-nav="dashboard">Debrief</a>
       <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/airframes" data-nav="airframes">Airframes</a>
       <a href="/weapons" data-nav="weapons">Weapons</a>
       <a href="/landings" data-nav="landings">Landings</a>
       <a href="/log" data-nav="log">Log</a>

--- a/web/player.html
+++ b/web/player.html
@@ -38,6 +38,7 @@
     <nav class="nav" aria-label="Sections">
       <a href="/" data-nav="dashboard">Debrief</a>
       <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/airframes" data-nav="airframes">Airframes</a>
       <a href="/weapons" data-nav="weapons">Weapons</a>
       <a href="/landings" data-nav="landings">Landings</a>
       <a href="/log" data-nav="log">Log</a>

--- a/web/weapons.html
+++ b/web/weapons.html
@@ -36,6 +36,7 @@
     <nav class="nav" aria-label="Sections">
       <a href="/" data-nav="dashboard">Debrief</a>
       <a href="/missions" data-nav="missions">Missions</a>
+      <a href="/airframes" data-nav="airframes">Airframes</a>
       <a href="/weapons" data-nav="weapons">Weapons</a>
       <a href="/landings" data-nav="landings">Landings</a>
       <a href="/log" data-nav="log">Log</a>


### PR DESCRIPTION
Stores have had a page since the section split. The machines that carry them have not — the reference card answers *"how did the Hornet do"*, but nothing answered *"compared with what else"*, which is exactly what the weapons table has been doing for stores all along.

```
Type              Sorties  Shots  Hits  Kills  Collisions  Lost   K/D  Hits/shot
F/A-18C Hornet       1046   1263  6627    397        1253    45  8.82       5.25
F-14B Tomcat          809   1458  8912    259        1486   148  1.75       6.11
9K330 Tor               0    850   383    176           0     0    —        0.45
```

68 types, paginated and sortable on every column, each name opening its reference card. Plus **Head to head** — the kill matrix between types across every pilot, which is the closest the data comes to a record between machines:

```
F-14B      → Su-27      69
Buk        → F-16C      53
F-14B      → Su-24M     50
Tor        → F-16C      43
```

## The collision split mattered more here than on weapons

DCS names the airframe as the weapon when an aircraft is flown into something. Counting those as kills made the **A-50 — an airborne early-warning radar carrying no weapons at all — the third deadliest aircraft on the server**, with 135 kills. It now reads what it actually is:

```
A-50    sorties 0    kills 0    collisions 990    lost 5
```

Same test as the weapons page, written against this query's aliases.

## Scope

Types are those seen as the *initiator* of something, which keeps scenery out without needing a second rule — a tree never took off or fired. A type that was only ever shot down still earns a row, because it still flew.

Verified: 68 types at all-time scope, `1–50 of 68` paging, kills-descending default, the collisions column appearing only because rows in view have them, and the matrix rendering 54 cells. Nav carries the section on every page. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)