### PR TITLE
Index the two columns every query filters on

### DIFF
--- a/models/eventModel.go
+++ b/models/eventModel.go
@@ -14,15 +14,26 @@ import (
 	WeaponID *uint  `json:"weaponid"`
 } */
 
+// Indexing note. Almost every query in the application starts by narrowing the
+// events table on the event type -- kill, shot, hit -- usually together with a
+// mission or a player. Those three were the only columns of interest that had
+// no index, while place and initiator_group, which nothing filters on, had one
+// each. With 293,157 rows that cost a full table scan per query and put the
+// pilot page at 2.5 seconds.
+//
+// The two composites below cover it. SQLite can use a leading subset of a
+// composite index, so (event, mission_id) also serves a bare event lookup and
+// (player_id, event) a bare player one; separate single-column indexes would be
+// redundant with these and only slow inserts further.
 type Event struct {
 	gorm.Model
-	PlayerID *uint
+	PlayerID *uint  `gorm:"index:idx_events_player_event,priority:1"`
 	Player   Player `gorm:"foreignKey:PlayerID;references:PlayerID"`
-	Event    string
+	Event    string `gorm:"index:idx_events_event_mission,priority:1;index:idx_events_player_event,priority:2"`
 	// MissionID ties the event to one run of a mission, so aggregates can be
 	// scoped to "this mission" instead of all of recorded history. Nullable
 	// because rows predate the missions table until the backfill has run.
-	MissionID *uint `gorm:"index"`
+	MissionID *uint `gorm:"index;index:idx_events_event_mission,priority:2"`
 	// MissionTime is the DCS mission clock in seconds, as reported by the event
 	// stream. CreatedAt records when overlord wrote the row, which drifts from
 	// the sim and does not survive a restart mid-mission; this is the timestamp
@@ -32,8 +43,10 @@ type Event struct {
 	// than on Player because a human can switch sides between sorties, so only
 	// the event knows which side they were on when it happened.
 	Coalition       string `gorm:"index"`
-	InitiatorUnitID *uint
-	Initiator       Unit `gorm:"foreignKey:InitiatorUnitID;references:UnitID"`
+	// Indexed because narrowing a pilot's page to one airframe, and the
+	// per-airframe aggregates, both filter through this join.
+	InitiatorUnitID *uint `gorm:"index"`
+	Initiator       Unit  `gorm:"foreignKey:InitiatorUnitID;references:UnitID"`
 	// InitiatorKind mirrors Target.Kind: an initiator can be a static, a weapon
 	// or scenery, not just a unit, and its type is stored in Initiator either
 	// way.


### PR DESCRIPTION
## The cause

`events` has **293,157 rows** and no index on `event` or `player_id` — the two columns almost every query in the application narrows on. `EXPLAIN QUERY PLAN` said what you would expect:

```
PLAN: kills with targets join     ->  SCAN events
PLAN: per-player kill slice       ->  SCAN events
```

Meanwhile `place` and `initiator_group`, which nothing filters on, each had an index of their own. The `gorm:"index"` tags had simply been put on the wrong columns.

## The fix

Two composites. SQLite can use a leading subset of a composite index, so `(event, mission_id)` also serves a bare `event` lookup and `(player_id, event)` a bare player one — separate single-column indexes would be redundant with these and only slow inserts further. `initiator_unit_id` gets one too, since narrowing a pilot to one airframe and the per-airframe aggregates both filter through that join.

## Measured, server-side

| Query | Before | After |
|---|---|---|
| `killPoints` (the map) | ~1.0 s | **0.15 s** |
| `playerProfile` — a human | ~2.1 s | **0.29 s** |
| `badges` | ~1.0 s | **0.62 s** |
| `missions` | — | 0.21 s |
| `missionIndex` | — | 0.54 s |
| `airframes` + matchups | — | 0.51 s |
| `healthcheck` (no database) | — | 0.003 s |

## What is still slow, and why it is not an index

The pilot page for a **synthetic AI player** stays at 1.8 s. That is structural, not indexing: those rows pool an entire coalition, so one "pilot" owns **117,000 events** and `GetPlayerProfile` runs fifteen separate aggregates over them. A human's page is 0.29 s because a human owns 1,653. Nobody browses the AI pages, so this is noted rather than fixed.

## Operational note

Migrations are a separate binary — the server does not run `AutoMigrate` at startup. The indexes appear only after:

```bash
go run ./migrate
```

It took ~4 s on the 293k-row table and grew the database from 105 MB to 117 MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)