### PR TITLE
Cache the mission list

### DIFF
--- a/controllers/aggregates.go
+++ b/controllers/aggregates.go
@@ -62,10 +62,12 @@ func scopeMission(missionID *uint) func(*gorm.DB) *gorm.DB {
 	}
 }
 
-// GetMissions lists recorded missions, newest first. Start, size and duration
+// loadMissions reads the mission list, newest first. Start, size and duration
 // are derived from the events rather than stored, so backfilled missions
 // report them exactly like live ones.
-func GetMissions() ([]*models.MissionSummary, error) {
+//
+// Callers want GetMissions, which memoises this; see missionCache.go for why.
+func loadMissions() ([]models.MissionSummary, error) {
 	// MIN over the id rather than over created_at: an aggregated timestamp
 	// comes back from SQLite as a bare string that will not scan into
 	// time.Time, where an integer id scans anywhere. The timestamps behind
@@ -120,9 +122,9 @@ func GetMissions() ([]*models.MissionSummary, error) {
 		}
 	}
 
-	result := make([]*models.MissionSummary, 0, len(rows))
+	result := make([]models.MissionSummary, 0, len(rows))
 	for _, r := range rows {
-		summary := &models.MissionSummary{
+		summary := models.MissionSummary{
 			MissionID: r.MissionID,
 			Name:      r.Name,
 			Theatre:   r.Theatre,

--- a/controllers/missionCache.go
+++ b/controllers/missionCache.go
@@ -1,0 +1,93 @@
+package controllers
+
+import (
+	"sync"
+	"time"
+
+	"github.com/MartinHell/overlord/models"
+)
+
+// The mission list is the one aggregate every page pays for.
+//
+// It is fetched outside the panel guards in the dashboard query, so it is not
+// optional the way the weapons table or the map are: every page asks for it,
+// every fifteen seconds, for as long as a tab is open. Three controllers --
+// badges, sorties and the mission index -- call it again server-side, so a
+// single request for /missions ran it twice.
+//
+// That would be unremarkable if it were cheap, but it is a LEFT JOIN over the
+// whole events table grouped down to one row per mission: 298,318 rows in,
+// 47 out, about 200ms. The cost that matters is not the latency. SQLite has a
+// single writer and that writer is the event ingester, running live while
+// people watch. Every open tab was adding a recurring full-table read against
+// the file being written to, which is how a busy mission gets SQLITE_BUSY.
+//
+// So the read is memoised. Nothing here needs to be exact: the list is a
+// dropdown, a heading and a mission count.
+
+// missionsTTL is deliberately shorter than the dashboard's fifteen-second
+// poll. The goal is not to make one tab's polling cheaper -- one tab is 200ms
+// per fifteen seconds, which is nothing -- it is to stop N tabs from costing N
+// times that. A window narrower than the poll interval collapses whatever
+// overlaps without letting anyone see a list older than they would have seen
+// anyway.
+const missionsTTL = 10 * time.Second
+
+var missionsCache struct {
+	mu sync.Mutex
+	// at zero means nothing cached, which is also how invalidation works.
+	at   time.Time
+	rows []models.MissionSummary
+}
+
+// GetMissions lists recorded missions, newest first.
+//
+// The lock is held across the query rather than only around the fields, so
+// callers arriving on a cold cache queue behind one query instead of starting
+// one each. Tabs opened together poll together, so that thundering herd is the
+// realistic case, not a rare one -- and serialising reads against SQLite is
+// what we want regardless.
+func GetMissions() ([]*models.MissionSummary, error) {
+	missionsCache.mu.Lock()
+	defer missionsCache.mu.Unlock()
+
+	if missionsCache.at.IsZero() || time.Since(missionsCache.at) > missionsTTL {
+		rows, err := loadMissions()
+		if err != nil {
+			// Leave whatever was cached alone. A failed refresh is a reason to
+			// serve a slightly old list, not to serve nothing.
+			if missionsCache.at.IsZero() {
+				return nil, err
+			}
+		} else {
+			missionsCache.rows = rows
+			missionsCache.at = time.Now()
+		}
+	}
+
+	// Callers get their own copy. MissionSummary is all value types, so this is
+	// a real copy rather than shared backing, and a caller that sorts or edits
+	// the slice it was handed cannot poison what everyone else sees.
+	out := make([]models.MissionSummary, len(missionsCache.rows))
+	copy(out, missionsCache.rows)
+
+	result := make([]*models.MissionSummary, len(out))
+	for i := range out {
+		result[i] = &out[i]
+	}
+
+	return result, nil
+}
+
+// invalidateMissions drops the cached list.
+//
+// Called when a mission starts and when one is named, which are the two changes
+// worth seeing immediately: a run appearing, and it stopping being "Mission
+// #48". Event counts and durations move constantly and are left to the TTL --
+// they are a number beside a heading, and the page they sit on only redraws
+// every fifteen seconds in any case.
+func invalidateMissions() {
+	missionsCache.mu.Lock()
+	missionsCache.at = time.Time{}
+	missionsCache.mu.Unlock()
+}

--- a/controllers/missionCache_test.go
+++ b/controllers/missionCache_test.go
@@ -1,0 +1,88 @@
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MartinHell/overlord/models"
+)
+
+// seedMissionCache fills the cache as a completed load would have, and puts it
+// back afterwards so the tests do not leak into each other.
+func seedMissionCache(t *testing.T, rows []models.MissionSummary) {
+	t.Helper()
+
+	missionsCache.mu.Lock()
+	missionsCache.rows = rows
+	missionsCache.at = time.Now()
+	missionsCache.mu.Unlock()
+
+	t.Cleanup(invalidateMissions)
+}
+
+// A warm cache must not touch the database. initializers.DB is nil in this test
+// binary, so a query would panic -- which is the assertion.
+func TestGetMissionsServesFromCache(t *testing.T) {
+	seedMissionCache(t, []models.MissionSummary{
+		{MissionID: 2, Name: "Op Foothold", Theatre: "Caucasus", Events: 400},
+		{MissionID: 1, Name: "Op Icebreaker", Theatre: "Syria", Events: 250},
+	})
+
+	got, err := GetMissions()
+	if err != nil {
+		t.Fatalf("expected a cached list, got error: %v", err)
+	}
+	if len(got) != 2 || got[0].MissionID != 2 || got[0].Name != "Op Foothold" {
+		t.Fatalf("expected the cached rows in order, got %+v", got)
+	}
+}
+
+// Callers get a copy. Badges, sorties and the mission index all take this list
+// and build on it; one of them sorting or rewriting it must not change what the
+// next caller sees.
+func TestGetMissionsHandsOutIsolatedCopies(t *testing.T) {
+	seedMissionCache(t, []models.MissionSummary{
+		{MissionID: 1, Name: "Op Icebreaker", Events: 250},
+	})
+
+	first, err := GetMissions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	first[0].Name = "clobbered"
+	first[0].Events = 0
+
+	second, err := GetMissions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if second[0].Name != "Op Icebreaker" || second[0].Events != 250 {
+		t.Fatalf("a caller's edits reached the cache: %+v", second[0])
+	}
+}
+
+// A mission starting, or being named, has to be visible before the TTL is up.
+func TestInvalidateMissionsForcesAReload(t *testing.T) {
+	seedMissionCache(t, []models.MissionSummary{{MissionID: 1}})
+
+	invalidateMissions()
+
+	missionsCache.mu.Lock()
+	stale := missionsCache.at.IsZero()
+	missionsCache.mu.Unlock()
+
+	if !stale {
+		t.Fatal("expected invalidation to mark the cache for reload")
+	}
+}
+
+// The TTL has to be under the dashboard's poll interval, or tabs polling
+// together stop overlapping inside one window and the cache buys nothing.
+func TestMissionsTTLIsShorterThanTheDashboardPoll(t *testing.T) {
+	const dashboardPoll = 15 * time.Second
+
+	if missionsTTL >= dashboardPoll {
+		t.Fatalf("missionsTTL %s must be under the %s poll", missionsTTL, dashboardPoll)
+	}
+}

--- a/controllers/missionTracker.go
+++ b/controllers/missionTracker.go
@@ -159,6 +159,11 @@ func (t *missionTracker) open(missionTime float64) {
 	t.clock = missionTime
 	logs.Sugar.Infof("Mission %d started (clock %.0fs)", mission.MissionID, missionTime)
 
+	// A run appearing is the one change to the list worth showing before the
+	// cache would have expired on its own -- it is what the dashboard watches
+	// for to follow the server onto the new mission.
+	invalidateMissions()
+
 	go annotateMission(mission.MissionID, false)
 }
 
@@ -204,5 +209,11 @@ func annotateMission(missionID uint, onlyIfEmpty bool) {
 		Where("mission_id = ?", missionID).
 		Updates(updates).Error; err != nil {
 		logs.Sugar.Errorf("Failed to annotate mission %d: %v", missionID, err)
+		return
 	}
+
+	// The name arrives a moment after the mission does, over gRPC. Without this
+	// the heading would read "Mission #48" for the rest of the TTL despite the
+	// row already knowing better.
+	invalidateMissions()
 }


### PR DESCRIPTION
## The problem

`missions { … }` sits at [app.js:157](web/app.js#L157) — **outside every `wants()` guard**. Unlike the weapons table or the map, it is not optional: every page requests it, and [app.js:2583](web/app.js#L2583) re-runs the whole dashboard query every 15 seconds per open tab. Three controllers — badges, sorties and the mission index — call `GetMissions` again server-side, so one request for `/missions` ran it twice.

It is a LEFT JOIN over the whole events table grouped to one row per mission: **298,318 rows in, 47 out, ~190 ms**.

**The cost that matters is not latency.** SQLite has a single writer and that writer is the event ingester, running live while people watch. Every open tab was adding a recurring full-table read against the file being written to — which is how a busy mission gets `SQLITE_BUSY`.

## The change

`GetMissions` memoises `loadMissions` behind a mutex.

- **The lock is held across the query**, not just around the fields. Tabs opened together poll together, so a cold-cache thundering herd is the realistic case — callers queue behind one query instead of starting one each. Serialising reads against SQLite is what we want regardless.
- **Callers get their own copy.** `MissionSummary` is all value types, so the copy is real; a caller that sorts or edits its slice cannot poison what everyone else sees.
- **TTL is under the 15 s poll** by design. The goal is not to make one tab cheaper — one tab is 190 ms per 15 s, which is nothing — it is to stop N tabs from costing N times that.
- **Explicit invalidation** on mission start and on mission naming: a run appearing, and it ceasing to be "Mission #48". Event counts and durations move constantly and are left to the TTL — they are a number beside a heading on a page that only redraws every 15 s anyway.
- **A failed refresh serves the stale list** rather than an error, unless nothing was ever cached.

## Measured on the live database

| | |
|---|---|
| cold | 0.190 s |
| warm | 0.003 s |
| after TTL expiry | 0.189 s (reloads, as intended) |
| 6 concurrent, cold | one query's worth of DB work, not six |
| 6 concurrent, warm | 0.004 s each |

## Tests

Four, covering what can be checked without a database harness (`controllers` has none): a warm cache serves without touching the DB — `initializers.DB` is nil in the test binary, so a query would panic, which is the assertion; callers get isolated copies; invalidation marks the cache for reload; and the TTL stays under the poll interval, since a TTL above it would buy nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)